### PR TITLE
Nouveaux champs dans le formulaire de revue

### DIFF
--- a/src/reviews/models.py
+++ b/src/reviews/models.py
@@ -640,3 +640,14 @@ class ReviewMixin(models.Model):
             'review_closed_on': review_closed_on
         })
         return context
+
+    def get_review_fields(self):
+        """Return data to display on the review form."""
+        fields = [
+            (_('Category'), self.document.category),
+            (_('Document number'), self.document.document_key),
+            (_('Title'), self.document.title),
+            (_('Status'), self.status),
+            (_('Revision'), self.name),
+        ]
+        return fields

--- a/src/reviews/views.py
+++ b/src/reviews/views.py
@@ -385,7 +385,6 @@ class ReviewFormView(LoginRequiredMixin, UpdateView):
             'close_leader_button': close_leader_button,
             'back_to_leader_button': back_to_leader_button,
             'can_discuss': can_discuss,
-            'form': form,
             'fields': self.revision.get_review_fields(),
         })
         return context

--- a/src/reviews/views.py
+++ b/src/reviews/views.py
@@ -373,7 +373,6 @@ class ReviewFormView(LoginRequiredMixin, UpdateView):
 
         context.update({
             'document': self.document,
-            'category': self.document.category,
             'document_key': self.document.document_key,
             'revision': self.revision,
             'reviews': all_reviews,
@@ -386,6 +385,8 @@ class ReviewFormView(LoginRequiredMixin, UpdateView):
             'close_leader_button': close_leader_button,
             'back_to_leader_button': back_to_leader_button,
             'can_discuss': can_discuss,
+            'form': form,
+            'fields': self.revision.get_review_fields(),
         })
         return context
 

--- a/src/reviews/views.py
+++ b/src/reviews/views.py
@@ -302,7 +302,8 @@ class ReviewFormView(LoginRequiredMixin, UpdateView):
     def get_object(self, queryset=None):
         document_key = self.kwargs.get('document_key')
         qs = Document.objects \
-            .filter(category__users=self.request.user)
+            .filter(category__users=self.request.user) \
+            .select_related()
         document = get_object_or_404(qs, document_key=document_key)
         revision = document.latest_revision
         review = revision.get_review(self.request.user)
@@ -372,6 +373,7 @@ class ReviewFormView(LoginRequiredMixin, UpdateView):
 
         context.update({
             'document': self.document,
+            'category': self.document.category,
             'document_key': self.document.document_key,
             'revision': self.revision,
             'reviews': all_reviews,

--- a/src/templates/reviews/review_form.html
+++ b/src/templates/reviews/review_form.html
@@ -7,6 +7,7 @@
         class="nav"
         data-spy="affix">
         <li><a href="#fieldset-general-information">General information</a></li>
+        <li><a href="#fieldset-files">Files</a></li>
         <li><a href="#fieldset-review-data">Review data</a></li>
         <li><a href="#fieldset-reviewers">Distribution list</a></li>
         <li><a href="#fieldset-your-comments">Your comments</a></li>
@@ -36,41 +37,18 @@
     <fieldset id="fieldset-general-information">
         <legend>{{ _('General information') }}</legend>
 
-        <div class="form-group">
-            <div class="control-label">{{ _('Category') }}</div>
-            <div class="controls">
-                <span class="uneditable-input">{{ category }}</span>
+        {% for label, value in fields %}
+            <div class="form-group">
+                <div class="control-label">{{ label }}</div>
+                <div class="controls">
+                    <span class="uneditable-input">{{ value }}</span>
+                </div>
             </div>
-        </div>
+        {% endfor %}
+    </fieldset>
 
-        <div class="form-group">
-            <div class="control-label">{{ _('Document number') }}</div>
-            <div class="controls">
-                <span class="uneditable-input">{{ revision.document.document_key }}</span>
-            </div>
-        </div>
-
-        <div class="form-group">
-            <div class="control-label">{{ _('Title') }}</div>
-            <div class="controls">
-                <p class="uneditable-input">{{ revision.document.title }}</p>
-            </div>
-        </div>
-
-        <div class="form-group">
-            <div class="control-label">{{ _('Status') }}</div>
-            <div class="controls">
-                <span class="uneditable-input">{{ revision.status }}</span>
-            </div>
-        </div>
-
-        <div class="form-group">
-            <div class="control-label">{{ _('Revision') }}</div>
-            <div class="controls">
-                <span class="uneditable-input">{{ revision.name }}</span>
-            </div>
-        </div>
-
+    <fieldset id="fieldset-files">
+        <legend>{{ _('Files') }}</legend>
         <div class="form-group">
             <div class="control-label">{{ _('Native file') }}</div>
             <div class="controls">

--- a/src/templates/reviews/review_form.html
+++ b/src/templates/reviews/review_form.html
@@ -37,6 +37,13 @@
         <legend>{{ _('General information') }}</legend>
 
         <div class="form-group">
+            <div class="control-label">{{ _('Category') }}</div>
+            <div class="controls">
+                <span class="uneditable-input">{{ category }}</span>
+            </div>
+        </div>
+
+        <div class="form-group">
             <div class="control-label">{{ _('Document number') }}</div>
             <div class="controls">
                 <span class="uneditable-input">{{ revision.document.document_key }}</span>


### PR DESCRIPTION
Les champs apparaissant dans le formulaire de documents sont maintenant configurables. Cette PR permet de traiter le ticket Talengi/sileodocs#19