### PR TITLE
Rename on the fly native_file and pdf_file to meet naming conventions

### DIFF
--- a/src/documents/fileutils.py
+++ b/src/documents/fileutils.py
@@ -8,8 +8,9 @@ def revision_file_path(revision, filename):
     based on the document number and the revision.
 
     """
-    return "revisions/{key}_{revision}.{extension}".format(
+    return "revisions/{key}_{revision}{status}.{extension}".format(
         key=revision.document.document_key,
         revision=revision.name,
-        extension=filename.split('.')[-1]
+        extension=filename.split('.')[-1],
+        status="_" + revision.status if hasattr(revision, 'status') else ''
     )


### PR DESCRIPTION
Patterns used :
*  documentnumber_revision_status.extension if status is not blank
*  documentnumber_revision.extension if status is blank