### PR TITLE
Document number

### DIFF
--- a/src/default_documents/forms.py
+++ b/src/default_documents/forms.py
@@ -21,6 +21,7 @@ class ContractorDeliverableForm(BaseDocumentForm):
         return Layout(
             DocumentFieldset(
                 _('General information'),
+                Field('document_key', type='hidden'),
                 'document_number',
                 Field('title', rows=2),
                 'contract_number',
@@ -51,7 +52,7 @@ class ContractorDeliverableForm(BaseDocumentForm):
 
     class Meta:
         model = ContractorDeliverable
-        exclude = ('document_key', 'document', 'latest_revision')
+        exclude = ('document', 'latest_revision')
 
 
 class ContractorDeliverableRevisionForm(ReviewFormMixin, BaseDocumentForm):
@@ -83,6 +84,7 @@ class CorrespondenceForm(BaseDocumentForm):
         return Layout(
             DocumentFieldset(
                 _('General information'),
+                Field('document_key', type='hidden'),
                 'document_number',
                 Field('subject', rows=2),
                 DateField('correspondence_date'),
@@ -103,7 +105,7 @@ class CorrespondenceForm(BaseDocumentForm):
 
     class Meta:
         model = Correspondence
-        exclude = ('document_key', 'document', 'latest_revision')
+        exclude = ('document', 'latest_revision')
 
 
 class CorrespondenceRevisionForm(BaseDocumentForm):
@@ -141,6 +143,7 @@ class MinutesOfMeetingForm(BaseDocumentForm):
         return Layout(
             DocumentFieldset(
                 _('General information'),
+                Field('document_key', type='hidden'),
                 'document_number',
                 Field('subject', rows=2),
                 DateField('meeting_date'),
@@ -158,7 +161,7 @@ class MinutesOfMeetingForm(BaseDocumentForm):
 
     class Meta:
         model = MinutesOfMeeting
-        exclude = ('document_key', 'document', 'latest_revision')
+        exclude = ('document', 'latest_revision')
 
 
 class MinutesOfMeetingRevisionForm(BaseDocumentForm):
@@ -186,12 +189,13 @@ class MinutesOfMeetingRevisionForm(BaseDocumentForm):
 class DemoMetadataForm(BaseDocumentForm):
     class Meta:
         model = DemoMetadata
-        exclude = ('document_key', 'document', 'latest_revision')
+        exclude = ('document', 'latest_revision')
 
     def build_layout(self):
         return Layout(
             DocumentFieldset(
                 _('General information'),
+                Field('document_key', type='hidden'),
                 'document_number',
                 Field('title', rows=2),
                 self.get_related_documents_layout(),

--- a/src/default_documents/forms.py
+++ b/src/default_documents/forms.py
@@ -21,7 +21,7 @@ class ContractorDeliverableForm(BaseDocumentForm):
         return Layout(
             DocumentFieldset(
                 _('General information'),
-                'document_key',
+                'document_number',
                 Field('title', rows=2),
                 'contract_number',
                 'originator',
@@ -51,7 +51,7 @@ class ContractorDeliverableForm(BaseDocumentForm):
 
     class Meta:
         model = ContractorDeliverable
-        exclude = ('document', 'latest_revision')
+        exclude = ('document_key', 'document', 'latest_revision')
 
 
 class ContractorDeliverableRevisionForm(ReviewFormMixin, BaseDocumentForm):
@@ -83,7 +83,7 @@ class CorrespondenceForm(BaseDocumentForm):
         return Layout(
             DocumentFieldset(
                 _('General information'),
-                'document_key',
+                'document_number',
                 Field('subject', rows=2),
                 DateField('correspondence_date'),
                 DateField('received_sent_date'),
@@ -103,7 +103,7 @@ class CorrespondenceForm(BaseDocumentForm):
 
     class Meta:
         model = Correspondence
-        exclude = ('document', 'latest_revision')
+        exclude = ('document_key', 'document', 'latest_revision')
 
 
 class CorrespondenceRevisionForm(BaseDocumentForm):
@@ -141,7 +141,7 @@ class MinutesOfMeetingForm(BaseDocumentForm):
         return Layout(
             DocumentFieldset(
                 _('General information'),
-                'document_key',
+                'document_number',
                 Field('subject', rows=2),
                 DateField('meeting_date'),
                 DateField('received_sent_date'),
@@ -158,7 +158,7 @@ class MinutesOfMeetingForm(BaseDocumentForm):
 
     class Meta:
         model = MinutesOfMeeting
-        exclude = ('document', 'latest_revision')
+        exclude = ('document_key', 'document', 'latest_revision')
 
 
 class MinutesOfMeetingRevisionForm(BaseDocumentForm):
@@ -186,13 +186,13 @@ class MinutesOfMeetingRevisionForm(BaseDocumentForm):
 class DemoMetadataForm(BaseDocumentForm):
     class Meta:
         model = DemoMetadata
-        exclude = ('document', 'latest_revision')
+        exclude = ('document_key', 'document', 'latest_revision')
 
     def build_layout(self):
         return Layout(
             DocumentFieldset(
                 _('General information'),
-                'document_key',
+                'document_number',
                 Field('title', rows=2),
                 self.get_related_documents_layout(),
             )

--- a/src/default_documents/migrations/0013_auto_20151210_1121.py
+++ b/src/default_documents/migrations/0013_auto_20151210_1121.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0012_auto_20151202_1413'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contractordeliverable',
+            name='document_number',
+            field=models.CharField(max_length=250, null=True, verbose_name='Document number'),
+        ),
+        migrations.AddField(
+            model_name='correspondence',
+            name='document_number',
+            field=models.CharField(max_length=250, null=True, verbose_name='Document number'),
+        ),
+        migrations.AddField(
+            model_name='demometadata',
+            name='document_number',
+            field=models.CharField(max_length=250, null=True, verbose_name='Document number'),
+        ),
+        migrations.AddField(
+            model_name='minutesofmeeting',
+            name='document_number',
+            field=models.CharField(max_length=250, null=True, verbose_name='Document number'),
+        ),
+        migrations.AlterField(
+            model_name='contractordeliverable',
+            name='document_key',
+            field=models.SlugField(unique=True, max_length=250, verbose_name='Document key'),
+        ),
+        migrations.AlterField(
+            model_name='correspondence',
+            name='document_key',
+            field=models.SlugField(unique=True, max_length=250, verbose_name='Document key'),
+        ),
+        migrations.AlterField(
+            model_name='demometadata',
+            name='document_key',
+            field=models.SlugField(unique=True, max_length=250, verbose_name='Document key'),
+        ),
+        migrations.AlterField(
+            model_name='minutesofmeeting',
+            name='document_key',
+            field=models.SlugField(unique=True, max_length=250, verbose_name='Document key'),
+        ),
+    ]

--- a/src/default_documents/migrations/0014_fill_document_numbers.py
+++ b/src/default_documents/migrations/0014_fill_document_numbers.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from documents.utils import get_all_document_classes
+from django.db.models import F
+
+
+def fill_document_numbers(apps, schema_editor):
+    classes = get_all_document_classes()
+    for _class in classes:
+        _class.objects.update(document_number=F('document_key'))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0013_auto_20151210_1121'),
+    ]
+
+    operations = [
+        migrations.RunPython(fill_document_numbers)
+    ]

--- a/src/default_documents/migrations/0015_auto_20151211_1055.py
+++ b/src/default_documents/migrations/0015_auto_20151211_1055.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0014_fill_document_numbers'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='contractordeliverable',
+            options={'ordering': ('document_number',)},
+        ),
+        migrations.AlterModelOptions(
+            name='demometadata',
+            options={'ordering': ('document_number',)},
+        ),
+        migrations.AlterModelOptions(
+            name='minutesofmeeting',
+            options={'ordering': ('document_number',)},
+        ),
+        migrations.AlterField(
+            model_name='contractordeliverable',
+            name='document_key',
+            field=models.SlugField(unique=True, max_length=250, verbose_name='Document key', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='contractordeliverable',
+            name='document_number',
+            field=models.CharField(max_length=250, verbose_name='Document number', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='correspondence',
+            name='document_key',
+            field=models.SlugField(unique=True, max_length=250, verbose_name='Document key', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='correspondence',
+            name='document_number',
+            field=models.CharField(max_length=250, verbose_name='Document number', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='demometadata',
+            name='document_key',
+            field=models.SlugField(unique=True, max_length=250, verbose_name='Document key', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='demometadata',
+            name='document_number',
+            field=models.CharField(max_length=250, verbose_name='Document number', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='minutesofmeeting',
+            name='document_key',
+            field=models.SlugField(unique=True, max_length=250, verbose_name='Document key', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='minutesofmeeting',
+            name='document_number',
+            field=models.CharField(max_length=250, verbose_name='Document number', blank=True),
+        ),
+    ]

--- a/src/default_documents/models.py
+++ b/src/default_documents/models.py
@@ -156,10 +156,10 @@ class ContractorDeliverable(Metadata):
             'docclass', 'status', 'unit', 'discipline',
             'document_type', 'under_review', 'overdue', 'leader', 'approver'
         )
-        searchable_fields = ('document_key', 'title',)
+        searchable_fields = ('document_number', 'title',)
         indexable_fields = ['is_existing', 'can_be_transmitted']
         column_fields = (
-            ('Document Number', 'document_key'),
+            ('Document Number', 'document_number'),
             ('Title', 'title'),
             ('Rev.', 'current_revision'),
             ('Status', 'status'),
@@ -176,7 +176,7 @@ class ContractorDeliverable(Metadata):
             ('Final revision', 'final_revision'),
         )
         transmittal_columns = {
-            'Document Number': 'document_key',
+            'Document Number': 'document_number',
             'Title': 'title',
             'Contract Number': 'contract_number',
             'Originator': 'originator',
@@ -191,7 +191,7 @@ class ContractorDeliverable(Metadata):
             'Created': 'created_on',
         }
         export_fields = OrderedDict((
-            ('Document number', 'document_key'),
+            ('Document number', 'document_number'),
             ('Title', 'title'),
             ('Revision', 'revision_name'),
             ('Revision date', 'revision_date'),
@@ -457,7 +457,7 @@ class Correspondence(Metadata):
         filter_fields = (
             'originator', 'recipient', 'status', 'overdue', 'leader')
         column_fields = (
-            ('Reference', 'document_key'),
+            ('Reference', 'document_number'),
             ('Subject', 'subject'),
             ('Rec./Sent date', 'received_sent_date'),
             ('Resp. required', 'response_required'),
@@ -471,7 +471,7 @@ class Correspondence(Metadata):
             ('Document type', 'document_type'),
         )
         searchable_fields = (
-            'document_key',
+            'document_number',
             'subject',
             'status',
             'leader',
@@ -601,7 +601,7 @@ class MinutesOfMeeting(Metadata):
             'originator', 'recipient', 'status', 'signed', 'prepared_by',
         )
         column_fields = (
-            ('Reference', 'document_key'),
+            ('Reference', 'document_number'),
             ('Subject', 'subject'),
             ('Meeting date', 'meeting_date'),
             ('Rec./sent date', 'received_sent_date'),
@@ -613,7 +613,7 @@ class MinutesOfMeeting(Metadata):
             ('Status', 'status'),
         )
         searchable_fields = (
-            'document_key',
+            'document_number',
             'subject',
             'originator',
             'recipient',
@@ -673,15 +673,15 @@ class DemoMetadata(Metadata):
     class PhaseConfig:
         filter_fields = ('status',)
         searchable_fields = (
-            'title', 'document_key', 'title',
+            'title', 'document_number', 'title',
         )
         column_fields = (
-            ('Document Number', 'document_key'),
+            ('Document Number', 'document_number'),
             ('Title', 'title'),
             ('Status', 'status'),
         )
         transmittal_columns = {
-            'Document Number': 'document_key',
+            'Document Number': 'document_number',
             'Title': 'title',
             'Contract Number': 'contract_number',
             'Originator': 'originator',

--- a/src/default_documents/models.py
+++ b/src/default_documents/models.py
@@ -176,7 +176,7 @@ class ContractorDeliverable(Metadata):
             ('Final revision', 'final_revision'),
         )
         transmittal_columns = {
-            'Document Number': 'document_number',
+            'Document Number': 'document_key',
             'Title': 'title',
             'Contract Number': 'contract_number',
             'Originator': 'originator',
@@ -238,7 +238,7 @@ class ContractorDeliverable(Metadata):
         )
 
     class Meta:
-        ordering = ('document_key',)
+        ordering = ('document_number',)
         unique_together = (
             (
                 "contract_number", "originator", "unit", "discipline",
@@ -588,7 +588,7 @@ class MinutesOfMeeting(Metadata):
         blank=True)
 
     class Meta:
-        ordering = ('document_key',)
+        ordering = ('document_number',)
         unique_together = (
             (
                 "contract_number", "originator", "recipient",
@@ -668,7 +668,7 @@ class DemoMetadata(Metadata):
         blank=True)
 
     class Meta:
-        ordering = ('document_key',)
+        ordering = ('document_number',)
 
     class PhaseConfig:
         filter_fields = ('status',)
@@ -681,7 +681,7 @@ class DemoMetadata(Metadata):
             ('Status', 'status'),
         )
         transmittal_columns = {
-            'Document Number': 'document_number',
+            'Document Number': 'document_key',
             'Title': 'title',
             'Contract Number': 'contract_number',
             'Originator': 'originator',

--- a/src/documents/factories.py
+++ b/src/documents/factories.py
@@ -16,6 +16,7 @@ class DocumentFactory(factory.DjangoModelFactory):
         model = Document
 
     document_key = factory.Sequence(lambda n: 'document-{0}'.format(n))
+    document_number = factory.SelfAttribute('document_key')
     current_revision = 1
     current_revision_date = fuzzy_date.fuzz()
     category = factory.SubFactory(CategoryFactory)
@@ -46,6 +47,7 @@ class DocumentFactory(factory.DjangoModelFactory):
         metadata_kwargs = {
             'document': obj,
             'document_key': obj.document_key,
+            'document_number': obj.document_number,
             'latest_revision': revision
         }
         metadata_kwargs.update(cls.metadata_kwargs)

--- a/src/documents/forms/models.py
+++ b/src/documents/forms/models.py
@@ -50,8 +50,8 @@ class BaseDocumentForm(forms.ModelForm):
         self.helper.layout = self.build_layout()
 
         # Document key is automatically generated, this field should not be required
-        if 'document_key' in self.fields:
-            self.fields['document_key'].required = False
+        if 'document_number' in self.fields:
+            self.fields['document_number'].required = False
 
     def build_layout(self):
         raise NotImplementedError('Missing "build_layout" method')

--- a/src/documents/forms/models.py
+++ b/src/documents/forms/models.py
@@ -108,9 +108,9 @@ class BaseDocumentForm(forms.ModelForm):
         # document number. Project History is the reason this is so complicated.
         # See ticket #145 for more details.
         if 'document_number' in data and 'document_key' in data:
-            if data['document_number'] and not data['document_key']:
-                data['document_key'] = slugify(data['document_number']).upper()
-            elif data['document_key'] and not data['document_number']:
+            if data['document_key'] and not data['document_number']:
                 data['document_number'] = data['document_key']
+            elif data['document_number']:
+                data['document_key'] = slugify(data['document_number']).upper()
 
         return data

--- a/src/documents/migrations/0003_auto_20151210_1039.py
+++ b/src/documents/migrations/0003_auto_20151210_1039.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('documents', '0002_document_favorited_by'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='document',
+            name='document_number',
+            field=models.CharField(max_length=250, null=True, verbose_name='Document number'),
+        ),
+        migrations.AlterField(
+            model_name='document',
+            name='document_key',
+            field=models.SlugField(unique=True, max_length=250, verbose_name='Document key'),
+        ),
+    ]

--- a/src/documents/migrations/0004_fill_document_numbers.py
+++ b/src/documents/migrations/0004_fill_document_numbers.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from django.db.models import F
+
+
+def fill_document_numbers(apps, schema_editor):
+    Document = apps.get_model('documents', 'Document')
+    Document.objects.update(document_number=F('document_key'))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('documents', '0003_auto_20151210_1039'),
+    ]
+
+    operations = [
+        migrations.RunPython(fill_document_numbers)
+    ]

--- a/src/documents/migrations/0005_auto_20151210_1045.py
+++ b/src/documents/migrations/0005_auto_20151210_1045.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('documents', '0004_fill_document_numbers'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='document',
+            name='document_number',
+            field=models.CharField(max_length=250, verbose_name='Document number'),
+        ),
+    ]

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -202,8 +202,6 @@ class Metadata(six.with_metaclass(MetadataBase, models.Model)):
 
     def save(self, *args, **kwargs):
         """Make sure the document has a document key."""
-        if not self.document_key:
-            self.document_key = self.generate_document_key()
         super(Metadata, self).save(*args, **kwargs)
 
         self.document.updated_on = timezone.now()

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -30,7 +30,6 @@ class Document(models.Model):
         max_length=250)
     document_number = models.CharField(
         _('Document number'),
-        null=True,
         max_length=250)
     title = models.TextField(
         verbose_name=u"Title")

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -24,9 +24,13 @@ class Document(models.Model):
     objects = DocumentManager()
 
     document_key = models.SlugField(
-        _('Document number'),
+        _('Document key'),
         unique=True,
         db_index=True,
+        max_length=250)
+    document_number = models.CharField(
+        _('Document number'),
+        null=True,
         max_length=250)
     title = models.TextField(
         verbose_name=u"Title")

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -197,7 +197,7 @@ class Metadata(six.with_metaclass(MetadataBase, models.Model)):
         max_length=250)
     document_number = models.CharField(
         _('Document number'),
-        null=True, blank=True,
+        blank=True,
         max_length=250)
 
     class Meta:

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -422,6 +422,8 @@ class MetadataRevision(models.Model):
         fields_infos = dict(fields)
         fields_infos.update({
             u'url': document.get_absolute_url(),
+            u'document_key': document.document_key,
+            u'document_number': document.document_number,
             u'document_pk': document.pk,
             u'metadata_pk': metadata.pk,
             u'pk': self.pk,

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -65,7 +65,7 @@ class Document(models.Model):
         permissions = (('can_control_document', 'Can control document'),)
 
     def __unicode__(self):
-        return self.document_key
+        return self.document_number
 
     def get_absolute_url(self):
         """Get the document url.

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -4,9 +4,10 @@ from collections import OrderedDict
 
 from django.db import models
 from django.db.models.base import ModelBase
-from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone, six
+from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
+
 from annoying.functions import get_object_or_None
 
 from accounts.models import User
@@ -189,9 +190,14 @@ class MetadataBase(ModelBase):
 class Metadata(six.with_metaclass(MetadataBase, models.Model)):
     document = models.OneToOneField(Document)
     document_key = models.SlugField(
-        _('Document number'),
+        _('Document key'),
+        blank=True,
         unique=True,
         db_index=True,
+        max_length=250)
+    document_number = models.CharField(
+        _('Document number'),
+        null=True, blank=True,
         max_length=250)
 
     class Meta:

--- a/src/documents/tests/casper_tests/tests.js
+++ b/src/documents/tests/casper_tests/tests.js
@@ -153,7 +153,7 @@ casper.test.begin('Selecting a row creates an input field in download form', 0, 
 casper.test.begin('Clicking a row redirects to the document page', 0, function suite(test) {
     casper.start(document_list_url, function() {
         test.assertUrlMatch(/\/organisation_\d+\/category_\d+\/$/);
-        casper.click('td.columndocument_key');
+        casper.click('td.columndocument_number');
     });
 
     casper.then(function() {
@@ -203,27 +203,27 @@ casper.test.begin('The filter form cannot be submitted', 0, function suite(test)
 
 casper.test.begin('Clicking a column sorts stuff', 0, function suite(test) {
     casper.start(document_list_url, function() {
-        test.assertExists('#columndocument_key span.glyphicon.glyphicon-chevron-down');
+        test.assertExists('#columndocument_number span.glyphicon.glyphicon-chevron-down');
         test.assertSelectorHasText('tbody tr:first-of-type td:nth-of-type(3)', 'hazop-report-0');
     });
 
     casper.then(function() {
-        casper.click('#columndocument_key');
+        casper.click('#columndocument_number');
         casper.wait(500);
     });
 
     casper.then(function() {
-        test.assertExists('#columndocument_key span.glyphicon.glyphicon-chevron-up');
+        test.assertExists('#columndocument_number span.glyphicon.glyphicon-chevron-up');
         test.assertSelectorHasText('tbody tr:first-of-type td:nth-of-type(3)', 'hazop-report-9');
     });
 
     casper.then(function() {
-        casper.click('#columndocument_key');
+        casper.click('#columndocument_number');
         casper.wait(500);
     });
 
     casper.then(function() {
-        test.assertExists('#columndocument_key span.glyphicon.glyphicon-chevron-down');
+        test.assertExists('#columndocument_number span.glyphicon.glyphicon-chevron-down');
         test.assertSelectorHasText('tbody tr:first-of-type td:nth-of-type(3)', 'hazop-report-0');
     });
 
@@ -233,7 +233,7 @@ casper.test.begin('Clicking a column sorts stuff', 0, function suite(test) {
     });
 
     casper.then(function() {
-        test.assertDoesntExist('#columndocument_key span.glyphicon');
+        test.assertDoesntExist('#columndocument_number span.glyphicon');
         test.assertExists('#columntitle span.glyphicon.glyphicon-chevron-down');
     });
 

--- a/src/documents/tests/test_forms.py
+++ b/src/documents/tests/test_forms.py
@@ -96,7 +96,7 @@ class DocumentCreateTest(TestCase):
             # Debug purpose
             self.assertEqual(r.context['form'].errors, {})
 
-    def test_creation_sets_document_key(self):
+    def test_creation_with_empty_document_key(self):
         """
         Tests that a document can be created with required fields.
         """
@@ -108,17 +108,21 @@ class DocumentCreateTest(TestCase):
             'received_date': '2015-10-10',
         }, follow=True)
         doc = Document.objects.all().order_by('-id')[0]
+        self.assertEqual(doc.document_number, 'a-title')
         self.assertEqual(doc.document_key, 'a-title')
 
+    def test_create_with_document_key(self):
+        c = self.client
         c.post(self.create_url, {
             'title': u'another title',
-            'document_key': u'gloubiboulga',
+            'document_number': u'Gloubi Boulga',
             'docclass': 1,
             'created_on': '2015-10-10',
             'received_date': '2015-10-10',
         }, follow=True)
         doc = Document.objects.all().order_by('-id')[0]
-        self.assertEqual(doc.document_key, 'gloubiboulga')
+        self.assertEqual(doc.document_number, 'Gloubi Boulga')
+        self.assertEqual(doc.document_key, 'GLOUBI-BOULGA')
 
     def test_creation_success_with_files(self):
         """
@@ -202,7 +206,7 @@ class DocumentCreateTest(TestCase):
             )
         ]
         c.post(self.create_url, {
-            'document_key': 'FAC09001-FWF-000-HSE-REP-0006',
+            'document_number': 'FAC09001-FWF-000-HSE-REP-0006',
             'title': u'HAZOP report',
             'docclass': 1,
             'created_on': '2015-10-10',
@@ -254,7 +258,7 @@ class DocumentEditTest(TestCase):
         r = c.get(edit_url)
         self.assertEqual(r.status_code, 200)
 
-        r = c.post(edit_url, {'document_key': doc.document_key})
+        r = c.post(edit_url, {'document_number': doc.document_key})
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.context['form'].errors, {
             'title': [required_error],
@@ -277,7 +281,7 @@ class DocumentEditTest(TestCase):
         )
         c = self.client
         r = c.post(doc.get_edit_url(), {
-            'document_key': doc.document_key,
+            'document_number': doc.document_key,
             'title': u'a new title',
         })
         if r.status_code == 302:
@@ -306,7 +310,7 @@ class DocumentEditTest(TestCase):
         )
         c = self.client
         r = c.post(doc.get_edit_url(), {
-            'document_key': doc.document_key,
+            'document_number': doc.document_key,
             'title': u'a new title',
             'docclass': 1,
             'created_on': '2015-10-10',
@@ -321,7 +325,7 @@ class DocumentEditTest(TestCase):
         )
 
         r = c.post(doc.get_edit_url(), {
-            'document_key': doc.document_key,
+            'document_number': doc.document_key,
             'title': u'a new new title',
             'docclass': 1,
             'created_on': '2015-10-10',
@@ -382,7 +386,7 @@ class DocumentReviseTest(TestCase):
             document.document_key
         ])
         res = self.client.post(url, {
-            'document_key': document.document_key,
+            'document_number': document.document_key,
             'title': document.metadata.title,
             'status': 'SPD',
             'docclass': 1,

--- a/src/documents/tests/test_models.py
+++ b/src/documents/tests/test_models.py
@@ -62,5 +62,6 @@ class DocumentTest(TestCase):
                 u'document_pk': document.pk,
                 u'metadata_pk': document.metadata.pk,
                 u'document_key': 'FAC09001-FWF-000-HSE-REP-0004',
+                u'document_number': 'FAC09001-FWF-000-HSE-REP-0004',
             }
         )

--- a/src/documents/utils.py
+++ b/src/documents/utils.py
@@ -107,6 +107,8 @@ def create_revision_from_forms(metadata_form, revision_form, category):
 
     document.current_revision = revision.revision
     document.current_revision_date = revision.revision_date
+    document.document_key = metadata.document_key
+    document.document_number = metadata.document_number
     document.save()
 
     signals.document_revised.send(
@@ -122,7 +124,11 @@ def update_revision_from_forms(metadata_form, revision_form, category):
     """Updates and existing document and revision."""
     revision = revision_form.save()
     metadata = metadata_form.save()
+
     document = metadata.document
+    document.document_key = metadata.document_key
+    document.document_number = metadata.document_number
+    document.save()
 
     signals.revision_edited.send(
         document=document,

--- a/src/documents/utils.py
+++ b/src/documents/utils.py
@@ -6,6 +6,7 @@ import tempfile
 
 from django.contrib.contenttypes.models import ContentType
 from django.utils.encoding import force_text
+from django.utils.text import slugify
 from django.db import transaction
 
 from documents import signals
@@ -55,10 +56,16 @@ def create_document_from_forms(metadata_form, revision_form, category, **doc_kwa
 
     # Extract the manually submitted document key, or generate one
     # if the field was left empty.
-    key = metadata.document_key or metadata.generate_document_key()
+    doc_number = metadata.document_number
+    if doc_number:
+        doc_key = slugify(doc_number).upper()
+    else:
+        doc_number = metadata.generate_document_key()
+        doc_key = doc_number
 
     document = Document.objects.create(
-        document_key=key,
+        document_key=doc_key,
+        document_number=doc_number,
         category=category,
         current_revision=revision.revision,
         current_revision_date=revision.revision_date,
@@ -70,7 +77,8 @@ def create_document_from_forms(metadata_form, revision_form, category, **doc_kwa
 
     metadata.document = document
     metadata.latest_revision = revision
-    metadata.document_key = key
+    metadata.document_key = doc_key
+    metadata.document_number = doc_number
     metadata.save()
     metadata_form.save_m2m()
 

--- a/src/documents/utils.py
+++ b/src/documents/utils.py
@@ -53,7 +53,10 @@ def create_document_from_forms(metadata_form, revision_form, category, **doc_kwa
     revision.revision = revision.get_first_revision_number()
     metadata = metadata_form.save(commit=False)
 
+    # Extract the manually submitted document key, or generate one
+    # if the field was left empty.
     key = metadata.document_key or metadata.generate_document_key()
+
     document = Document.objects.create(
         document_key=key,
         category=category,

--- a/src/documents/utils.py
+++ b/src/documents/utils.py
@@ -6,7 +6,6 @@ import tempfile
 
 from django.contrib.contenttypes.models import ContentType
 from django.utils.encoding import force_text
-from django.utils.text import slugify
 from django.db import transaction
 
 from documents import signals
@@ -58,7 +57,7 @@ def create_document_from_forms(metadata_form, revision_form, category, **doc_kwa
     # if the field was left empty.
     doc_number = metadata.document_number
     if doc_number:
-        doc_key = slugify(doc_number).upper()
+        doc_key = metadata.document_key
     else:
         doc_number = metadata.generate_document_key()
         doc_key = doc_number

--- a/src/reviews/models.py
+++ b/src/reviews/models.py
@@ -645,7 +645,7 @@ class ReviewMixin(models.Model):
         """Return data to display on the review form."""
         fields = [
             (_('Category'), self.document.category),
-            (_('Document number'), self.document.document_key),
+            (_('Document number'), self.document.document_number),
             (_('Title'), self.document.title),
             (_('Status'), self.status),
             (_('Revision'), self.name),

--- a/src/reviews/tests/test_forms.py
+++ b/src/reviews/tests/test_forms.py
@@ -111,6 +111,7 @@ class UpdateDistribListTests(BaseReviewFormMixinTests):
             'leader': self.user2.id,
             'approver': self.user3.id,
             'review_start_date': datetime.datetime.today(),
+            'review_due_date': datetime.datetime.today() + datetime.timedelta(days=14)
         })
 
     def test_form_is_valid(self):

--- a/src/static/js/documents/models.js
+++ b/src/static/js/documents/models.js
@@ -19,7 +19,7 @@ var Phase = Phase || {};
         defaults: function() {
             var defaults = {
                 search_terms: '',
-                sort_by: 'document_key',
+                sort_by: 'document_number',
                 start: 0,
                 size: Phase.Config.paginateBy
             };

--- a/src/templates/documents/document_detail.html
+++ b/src/templates/documents/document_detail.html
@@ -13,7 +13,7 @@
         {% include 'documents/document_detail_actions.html' with dropdirection='dropdown' %}
         <hr />
 
-        <h1>{{ document.document_key }}</h1>
+        <h1>{{ document.document_number }}</h1>
         <form class="disabled" id="document-detail">
             {% crispy form form.helper %}
             {% include 'documents/document_revisions.html' with revisions=revisions %}

--- a/src/templates/documents/document_form.html
+++ b/src/templates/documents/document_form.html
@@ -19,16 +19,16 @@
 
         {% if is_edit and not is_revise %}
             <p class="alert alert-info">
-            {% blocktrans with document_key=document.document_key revision=revision.name %}
+            {% blocktrans with document_number=document.document_number revision=revision.name %}
                 You are editing rev <strong>{{ revision }}</strong> of the
-                document <strong>{{ document_key }}</strong>.
+                document <strong>{{ document_number }}</strong>.
             {% endblocktrans %}
             </p>
         {% elif is_revise %}
             <p class="alert alert-info">
-            {% blocktrans with document_key=document.document_key revision=next_revision %}
+            {% blocktrans with document_number=document.document_number revision=next_revision %}
                 You are creating revision <strong>{{ revision }}</strong> of
-                the document <strong>{{ document_key }}</strong>.
+                the document <strong>{{ document_number }}</strong>.
             {% endblocktrans %}
             </p>
         {% endif %}

--- a/src/templates/favorites/favorite_list.html
+++ b/src/templates/favorites/favorite_list.html
@@ -26,7 +26,7 @@
             {% for favorite in favorite_list %}
                 <tr>
                     <td><a href="{{ favorite.document.get_absolute_url }}">
-                            {{ favorite.document.document_key }}
+                            {{ favorite.document }}
                         </a>
                     </td>
                     <td class="columntitle">{{ favorite.document.title }}</td>

--- a/src/templates/reviews/review_list.html
+++ b/src/templates/reviews/review_list.html
@@ -39,7 +39,7 @@
                     </td>
                 {% endif %}
                 <td class="columndocument_key">
-                    <a href="{% url 'review_document' rev.document.document_key %}">{{ rev.document.document_key }}</a>
+                    <a href="{% url 'review_document' rev.document.document_key %}">{{ rev.document.document_number }}</a>
                 </td>
                 <td class="columntitle">
                     <a href="{% url 'review_document' rev.document.document_key %}">{{ rev.document.title }}</a>

--- a/src/templates/transmittals/layout/related_revisions.html
+++ b/src/templates/transmittals/layout/related_revisions.html
@@ -14,7 +14,7 @@
             <tbody>
             {% for rev in revisions %}
             <tr>
-                <td>{{ rev.document.document_key }}</td>
+                <td>{{ rev.document.document_number }}</td>
                 <td>{{ rev.document.title }}</td>
                 <td>{{ rev.name }}</td>
                 <td>{{ rev.status }}</td>

--- a/src/templates/transmittals/revision_diff_view.html
+++ b/src/templates/transmittals/revision_diff_view.html
@@ -31,8 +31,8 @@
             <tbody>
             <tr class="{% diffclass 'document_key' %}">
                 <th>Document number</th>
-                <td>{{ revision.document_key }}</td>
-                <td>{{ trs_revision.document_key }}</td>
+                <td>{{ revision.document_number }}</td>
+                <td>{{ trs_revision.document_number }}</td>
             </tr>
             <tr class="{% diffclass 'title' %}">
                 <th>Title</th>

--- a/src/transmittals/forms.py
+++ b/src/transmittals/forms.py
@@ -22,7 +22,7 @@ class TransmittalForm(BaseDocumentForm):
             Field('rejected_dir', type='hidden'),
             DocumentFieldset(
                 _('General information'),
-                'document_key',
+                'document_number',
                 DateField('transmittal_date'),
                 DateField('ack_of_receipt_date'),
                 'contract_number',
@@ -35,8 +35,8 @@ class TransmittalForm(BaseDocumentForm):
 
     class Meta:
         model = Transmittal
-        exclude = ('document', 'latest_revision', 'status', 'transmittal_key',
-                   'document_type', 'contractor',)
+        exclude = ('document_key', 'document', 'latest_revision', 'status',
+                   'transmittal_key', 'document_type', 'contractor',)
 
 
 class TransmittalRevisionForm(BaseDocumentForm):
@@ -71,7 +71,7 @@ class OutgoingTransmittalForm(BaseDocumentForm):
         return Layout(
             DocumentFieldset(
                 _('General information'),
-                'document_key',
+                'document_number',
                 'contract_number',
                 'originator',
                 'recipient',
@@ -83,7 +83,8 @@ class OutgoingTransmittalForm(BaseDocumentForm):
 
     class Meta:
         model = OutgoingTransmittal
-        exclude = ('document', 'latest_revision', 'related_documents')
+        exclude = ('document_key', 'document', 'latest_revision',
+                   'related_documents')
 
 
 class OutgoingTransmittalRevisionForm(BaseDocumentForm):

--- a/src/transmittals/forms.py
+++ b/src/transmittals/forms.py
@@ -22,6 +22,7 @@ class TransmittalForm(BaseDocumentForm):
             Field('rejected_dir', type='hidden'),
             DocumentFieldset(
                 _('General information'),
+                Field('document_key', type='hidden'),
                 'document_number',
                 DateField('transmittal_date'),
                 DateField('ack_of_receipt_date'),
@@ -35,7 +36,7 @@ class TransmittalForm(BaseDocumentForm):
 
     class Meta:
         model = Transmittal
-        exclude = ('document_key', 'document', 'latest_revision', 'status',
+        exclude = ('document', 'latest_revision', 'status',
                    'transmittal_key', 'document_type', 'contractor',)
 
 
@@ -71,6 +72,7 @@ class OutgoingTransmittalForm(BaseDocumentForm):
         return Layout(
             DocumentFieldset(
                 _('General information'),
+                Field('document_key', type='hidden'),
                 'document_number',
                 'contract_number',
                 'originator',
@@ -83,7 +85,7 @@ class OutgoingTransmittalForm(BaseDocumentForm):
 
     class Meta:
         model = OutgoingTransmittal
-        exclude = ('document_key', 'document', 'latest_revision',
+        exclude = ('document', 'latest_revision',
                    'related_documents')
 
 

--- a/src/transmittals/migrations/0014_auto_20151210_1121.py
+++ b/src/transmittals/migrations/0014_auto_20151210_1121.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0013_auto_20151202_1413'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='outgoingtransmittal',
+            name='document_number',
+            field=models.CharField(max_length=250, null=True, verbose_name='Document number'),
+        ),
+        migrations.AddField(
+            model_name='transmittal',
+            name='document_number',
+            field=models.CharField(max_length=250, null=True, verbose_name='Document number'),
+        ),
+        migrations.AlterField(
+            model_name='outgoingtransmittal',
+            name='document_key',
+            field=models.SlugField(unique=True, max_length=250, verbose_name='Document key'),
+        ),
+        migrations.AlterField(
+            model_name='transmittal',
+            name='document_key',
+            field=models.SlugField(unique=True, max_length=250, verbose_name='Document key'),
+        ),
+    ]

--- a/src/transmittals/migrations/0015_auto_20151211_1055.py
+++ b/src/transmittals/migrations/0015_auto_20151211_1055.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0014_auto_20151210_1121'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='outgoingtransmittal',
+            options={'ordering': ('document_number',), 'verbose_name': 'Outgoing transmittal', 'verbose_name_plural': 'Outgoing transmittals'},
+        ),
+        migrations.AlterModelOptions(
+            name='transmittal',
+            options={'ordering': ('document_number',), 'verbose_name': 'Transmittal', 'verbose_name_plural': 'Transmittals'},
+        ),
+        migrations.AlterField(
+            model_name='outgoingtransmittal',
+            name='document_key',
+            field=models.SlugField(unique=True, max_length=250, verbose_name='Document key', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='outgoingtransmittal',
+            name='document_number',
+            field=models.CharField(max_length=250, verbose_name='Document number', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='transmittal',
+            name='document_key',
+            field=models.SlugField(unique=True, max_length=250, verbose_name='Document key', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='transmittal',
+            name='document_number',
+            field=models.CharField(max_length=250, verbose_name='Document number', blank=True),
+        ),
+    ]

--- a/src/transmittals/models.py
+++ b/src/transmittals/models.py
@@ -112,7 +112,7 @@ class Transmittal(Metadata):
             'originator', 'recipient', 'status',
         )
         column_fields = (
-            ('Reference', 'document_key'),
+            ('Reference', 'document_number'),
             ('Transmittal date', 'transmittal_date'),
             ('Ack. of receipt date', 'ack_of_receipt_date'),
             ('Originator', 'originator'),
@@ -121,7 +121,7 @@ class Transmittal(Metadata):
             ('Status', 'status'),
         )
         searchable_fields = (
-            'document_key',
+            'document_number',
             'originator',
             'recipient',
             'document_type',
@@ -498,13 +498,13 @@ class OutgoingTransmittal(Metadata):
     class PhaseConfig:
         filter_fields = ('contract_number', 'ack_of_receipt')
         column_fields = (
-            ('Reference', 'document_key'),
+            ('Reference', 'document_number'),
             ('Originator', 'originator'),
             ('Recipient', 'recipient'),
             ('Ack of receipt', 'ack_of_receipt'),
         )
         searchable_fields = (
-            'document_key',
+            'document_number',
             'originator',
             'recipient',
         )

--- a/src/transmittals/models.py
+++ b/src/transmittals/models.py
@@ -99,7 +99,7 @@ class Transmittal(Metadata):
 
     class Meta:
         app_label = 'transmittals'
-        ordering = ('document_key',)
+        ordering = ('document_number',)
         verbose_name = _('Transmittal')
         verbose_name_plural = _('Transmittals')
         index_together = (
@@ -491,7 +491,7 @@ class OutgoingTransmittal(Metadata):
 
     class Meta:
         app_label = 'transmittals'
-        ordering = ('document_key',)
+        ordering = ('document_number',)
         verbose_name = _('Outgoing transmittal')
         verbose_name_plural = _('Outgoing transmittals')
 

--- a/src/transmittals/pdf.py
+++ b/src/transmittals/pdf.py
@@ -133,7 +133,7 @@ class TransmittalPdf(object):
             self.revision.created_on,
             'd/m/Y')
         data = [
-            ('Transmittal Number', self.document.document_key),
+            ('Transmittal Number', self.document.document_number),
             ('Issue Date', date),
         ]
         table = Table(data, hAlign='LEFT', colWidths=[70 * mm, 60 * mm])
@@ -184,7 +184,7 @@ class TransmittalPdf(object):
         data = [header]
         for revision in self.revisions:
             data.append((
-                Paragraph(revision.document.document_key, body_style),
+                Paragraph(revision.document.document_number, body_style),
                 Paragraph(revision.title, body_style),
                 Paragraph(revision.name, centered),
                 Paragraph(revision.status, centered),


### PR DESCRIPTION
Fixes #145

Gestion de deux champs séparés pour le document number.

Le premier « document_key » est un slug destiné à être utilisé dans les urls et comme identifiant en base de données.

Le second « document_number » peut contenir des caractères spéciaux et est destiné à l'affichage.