### PR TITLE
Restrict some navbar items to admins and controllers

### DIFF
--- a/src/accounts/tests/test_views.py
+++ b/src/accounts/tests/test_views.py
@@ -28,6 +28,8 @@ class NavigationTests(TestCase):
         self.assertNotContains(res, '<a href="#nav-organisations"')
         self.assertNotContains(res, 'href="%s"' % self.create_url)
         self.assertNotContains(res, 'href="/admin/"')
+        self.assertNotContains(res, '<a href="#nav-transmittals"')
+        self.assertNotContains(res, '<a href="#nav-imports"')
 
     def test_authenticated_user_navbar(self):
         self.client.login(username=self.user.email, password='pass')
@@ -38,6 +40,8 @@ class NavigationTests(TestCase):
         self.assertContains(res, '<a href="#nav-organisations"')
         self.assertNotContains(res, 'href="%s"' % self.create_url)
         self.assertNotContains(res, 'href="/admin/"')
+        self.assertNotContains(res, '<a href="#nav-transmittals"')
+        self.assertNotContains(res, '<a href="#nav-imports"')
 
     def test_document_controller_navbar(self):
         self.user.user_permissions = self.dc_perms
@@ -52,6 +56,8 @@ class NavigationTests(TestCase):
         self.assertContains(res, '<a href="#nav-organisations"')
         self.assertContains(res, 'href="%s"' % self.create_url)
         self.assertNotContains(res, 'href="/admin/"')
+        self.assertContains(res, '<a href="#nav-transmittals"')
+        self.assertContains(res, '<a href="#nav-imports"')
 
     def test_admin_navbar(self):
         self.user.is_superuser = True
@@ -64,6 +70,8 @@ class NavigationTests(TestCase):
         self.assertContains(res, '<a href="#nav-organisations"')
         self.assertContains(res, 'href="%s"' % self.create_url)
         self.assertContains(res, 'href="/admin/"')
+        self.assertContains(res, '<a href="#nav-transmittals"')
+        self.assertContains(res, '<a href="#nav-imports"')
 
 
 class AclTests(TestCase):

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -58,6 +58,8 @@ class Document(models.Model):
         verbose_name_plural = _('Documents')
 
         # Custom permission for document controllers
+        # Permission used in sidebar template to check if user belongs to
+        # doc controller group
         permissions = (('can_control_document', 'Can control document'),)
 
     def __unicode__(self):

--- a/src/templates/left_column.html
+++ b/src/templates/left_column.html
@@ -12,9 +12,15 @@
     <ul id="sidebar-nav" class="nav nav-stacked">
         {% include 'documents/categories_menu.html' %}
         {% include 'reviews/review_menu.html' %}
-        {% include 'transmittals/transmittal_menu.html' %}
+        {# only superusers and doc controller can see transmittals import menu items #}
+        {#  the easiest way to know if user is a doc controller is to check the `documents.add_document` permission #}
+        {%  if user.is_superuser or perms.documents.add_document %}
+            {% include 'transmittals/transmittal_menu.html' %}
+        {% endif %}
         {% include 'favorites/favorites_menu.html' %}
-        {% include 'imports/import_menu.html' %}
+        {%  if user.is_superuser or perms.documents.add_document %}
+            {% include 'imports/import_menu.html' %}
+        {%  endif %}
         {% include 'exports/export_menu.html' %}
         {% include 'dashboards/dashboard_menu.html' %}
     </ul>


### PR DESCRIPTION
Build navbar to show transmittals and import items only to admins and document controllers