### PR TITLE
Allow sidebar filter fields to be easily ordered

### DIFF
--- a/src/documents/forms/filters.py
+++ b/src/documents/forms/filters.py
@@ -67,7 +67,7 @@ def filterform_factory(model):
     revision_model = model.latest_revision.get_queryset().model
     all_fields = dict((field.name, field) for field in (
         model._meta.concrete_fields + revision_model._meta.concrete_fields))
-
+    # import pdb;pdb.set_trace()
     # Get the list of all configured fields
     config = getattr(model, 'PhaseConfig')
     field_list = []
@@ -118,11 +118,12 @@ def filterform_factory(model):
         # Trick used in django admin:
         # https://github.com/django/django/blob/1.8/django/contrib/auth/forms.py#L318
 
-        # These hidden fields belong to `BaseDocumentFilterForm`.
+        # These hidden fields belong to `BaseDocumentFilterForm` or are added
+        # above.
         # We have to add them to the `base_fields` by appending them to the
         # `filter_fields_order` list manually.
         # TODO Find a better way to do this.
-        filter_fields_order = ['size', 'start'] + filter_fields_order
+        fields_order = ['size', 'start'] + filter_fields_order
         form.base_fields = OrderedDict(
-            (k, form.base_fields[k]) for k in filter_fields_order)
+            (k, form.base_fields[k]) for k in fields_order)
     return form

--- a/src/documents/forms/filters.py
+++ b/src/documents/forms/filters.py
@@ -1,62 +1,64 @@
+from collections import OrderedDict
+
 from django import forms
-from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
 
 
 class BaseDocumentFilterForm(forms.Form):
     """Base form for filtering documents of any type."""
     size = forms.IntegerField(
-        widget=forms.HiddenInput(),
-        required=False,
-        initial=settings.PAGINATE_BY)
+            widget=forms.HiddenInput(),
+            required=False,
+            initial=settings.PAGINATE_BY)
     start = forms.IntegerField(
-        widget=forms.HiddenInput(),
-        required=False,
-        initial=0)
+            widget=forms.HiddenInput(),
+            required=False,
+            initial=0)
     search_terms = forms.CharField(
-        label=u'Search all columns',
-        required=False)
+            label=u'Search all columns',
+            required=False)
 
 
-# Additional fields that could be needed, e.g for filter fiedls that are
+# Additional fields that could be needed, e.g for filter fields that are
 # not model fields.
 # TODO Find a better way to do this.
 additional_filter_fields = {
     'overdue': forms.ChoiceField(
-        choices=(
-            ('', '---------'),
-            ('true', 'Yes'),
-            ('false', 'No')
-        ),
-        required=False,
-        widget=forms.Select,
-        label=_('Overdue'),
+            choices=(
+                ('', '---------'),
+                ('true', 'Yes'),
+                ('false', 'No')
+            ),
+            required=False,
+            widget=forms.Select,
+            label=_('Overdue'),
     ),
     'under_review': forms.ChoiceField(
-        choices=(
-            ('', '---------'),
-            ('true', 'Yes'),
-            ('false', 'No')
-        ),
-        required=False,
-        widget=forms.Select,
-        label=_('Under review'),
+            choices=(
+                ('', '---------'),
+                ('true', 'Yes'),
+                ('false', 'No')
+            ),
+            required=False,
+            widget=forms.Select,
+            label=_('Under review'),
     ),
     'ack_of_receipt': forms.ChoiceField(
-        choices=(
-            ('', '---------'),
-            ('true', 'Yes'),
-            ('false', 'No')
-        ),
-        required=False,
-        widget=forms.Select,
-        label=_('Ack of receipt'),
+            choices=(
+                ('', '---------'),
+                ('true', 'Yes'),
+                ('false', 'No')
+            ),
+            required=False,
+            widget=forms.Select,
+            label=_('Ack of receipt'),
     )
 }
 
 
 def filterform_factory(model):
-    """Dynamicaly create a filter form for the given Metadata model.
+    """Dynamically create a filter form for the given Metadata model.
 
     Filter fields can be either located in the Metadata class, or in the
     corresponding Revision class.
@@ -73,6 +75,10 @@ def filterform_factory(model):
 
     # Add all field filters to form
     filter_fields = config.filter_fields
+
+    # Get the optional `filter_fields_order` in PhaseConfig
+    filter_fields_order = getattr(config, 'filter_fields_order', None)
+
     for field_name in filter_fields:
         if field_name in all_fields:
             f = all_fields[field_name]
@@ -96,13 +102,27 @@ def filterform_factory(model):
         field.required = False
         field.label = filter_config['label']
         field_list.append((field_name, field))
-
-    field_list = dict(field_list)
-    field_list.update({
-        'sort_by': forms.CharField(
-            widget=forms.HiddenInput(),
-            required=False,
-            initial=model._meta.ordering[0])
-    })
+    field_list.append((
+        'sort_by', forms.CharField(
+                widget=forms.HiddenInput(),
+                required=False,
+                initial=model._meta.ordering[0])
+    ))
     class_name = model.__name__ + 'FilterForm'
-    return type(class_name, (BaseDocumentFilterForm,), dict(field_list))
+    field_dict = OrderedDict(field_list)
+
+    form = type(class_name, (BaseDocumentFilterForm,), field_dict)
+
+    if filter_fields_order:
+        # We need to modify `base_fields` to get the wanted order
+        # Trick used in django admin:
+        # https://github.com/django/django/blob/1.8/django/contrib/auth/forms.py#L318
+
+        # These hidden fields belong to `BaseDocumentFilterForm`.
+        # We have to add them to the `base_fields` by appending them to the
+        # `filter_fields_order` list manually.
+        # TODO Find a better way to do this.
+        filter_fields_order = ['size', 'start'] + filter_fields_order
+        form.base_fields = OrderedDict(
+                (k, form.base_fields[k]) for k in filter_fields_order )
+    return form

--- a/src/documents/forms/filters.py
+++ b/src/documents/forms/filters.py
@@ -8,16 +8,16 @@ from django.utils.translation import ugettext_lazy as _
 class BaseDocumentFilterForm(forms.Form):
     """Base form for filtering documents of any type."""
     size = forms.IntegerField(
-            widget=forms.HiddenInput(),
-            required=False,
-            initial=settings.PAGINATE_BY)
+        widget=forms.HiddenInput(),
+        required=False,
+        initial=settings.PAGINATE_BY)
     start = forms.IntegerField(
-            widget=forms.HiddenInput(),
-            required=False,
-            initial=0)
+        widget=forms.HiddenInput(),
+        required=False,
+        initial=0)
     search_terms = forms.CharField(
-            label=u'Search all columns',
-            required=False)
+        label=u'Search all columns',
+        required=False)
 
 
 # Additional fields that could be needed, e.g for filter fields that are
@@ -25,34 +25,34 @@ class BaseDocumentFilterForm(forms.Form):
 # TODO Find a better way to do this.
 additional_filter_fields = {
     'overdue': forms.ChoiceField(
-            choices=(
-                ('', '---------'),
-                ('true', 'Yes'),
-                ('false', 'No')
-            ),
-            required=False,
-            widget=forms.Select,
-            label=_('Overdue'),
+        choices=(
+            ('', '---------'),
+            ('true', 'Yes'),
+            ('false', 'No')
+        ),
+        required=False,
+        widget=forms.Select,
+        label=_('Overdue'),
     ),
     'under_review': forms.ChoiceField(
-            choices=(
-                ('', '---------'),
-                ('true', 'Yes'),
-                ('false', 'No')
-            ),
-            required=False,
-            widget=forms.Select,
-            label=_('Under review'),
+        choices=(
+            ('', '---------'),
+            ('true', 'Yes'),
+            ('false', 'No')
+        ),
+        required=False,
+        widget=forms.Select,
+        label=_('Under review'),
     ),
     'ack_of_receipt': forms.ChoiceField(
-            choices=(
-                ('', '---------'),
-                ('true', 'Yes'),
-                ('false', 'No')
-            ),
-            required=False,
-            widget=forms.Select,
-            label=_('Ack of receipt'),
+        choices=(
+            ('', '---------'),
+            ('true', 'Yes'),
+            ('false', 'No')
+        ),
+        required=False,
+        widget=forms.Select,
+        label=_('Ack of receipt'),
     )
 }
 
@@ -104,9 +104,9 @@ def filterform_factory(model):
         field_list.append((field_name, field))
     field_list.append((
         'sort_by', forms.CharField(
-                widget=forms.HiddenInput(),
-                required=False,
-                initial=model._meta.ordering[0])
+            widget=forms.HiddenInput(),
+            required=False,
+            initial=model._meta.ordering[0])
     ))
     class_name = model.__name__ + 'FilterForm'
     field_dict = OrderedDict(field_list)
@@ -124,5 +124,5 @@ def filterform_factory(model):
         # TODO Find a better way to do this.
         filter_fields_order = ['size', 'start'] + filter_fields_order
         form.base_fields = OrderedDict(
-                (k, form.base_fields[k]) for k in filter_fields_order )
+            (k, form.base_fields[k]) for k in filter_fields_order)
     return form

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -176,10 +176,10 @@ class MetadataBase(ModelBase):
 
             filter_fields = getattr(phase_config, 'filter_fields', None)
             searchable_fields = getattr(
-                    phase_config, 'searchable_fields', None)
+                phase_config, 'searchable_fields', None)
             column_fields = getattr(phase_config, 'column_fields', None)
             filter_fields_order = getattr(
-                    phase_config, 'filter_fields_order', None)
+                phase_config, 'filter_fields_order', None)
 
             if not all((filter_fields, searchable_fields, column_fields)):
                 raise TypeError('Your "PhaseConfig" definition is incorrect '
@@ -188,11 +188,11 @@ class MetadataBase(ModelBase):
             if filter_fields_order:
                 if not set(filter_fields) <= set(filter_fields_order):
                     raise TypeError(
-                            'Your "PhaseConfig" definition is incorrect '
-                            '"filter_fields_order" should contain the same '
-                            'elements as "filter_fields" and the base'
-                            ' visible fields from'
-                            ' "documents.forms.BaseDocumentFilterForm"')
+                        'Your "PhaseConfig" definition is incorrect '
+                        '"filter_fields_order" should contain the same '
+                        'elements as "filter_fields" and the base'
+                        ' visible fields from'
+                        ' "documents.forms.BaseDocumentFilterForm"')
 
         return super(MetadataBase, cls).__new__(cls, name, bases, attrs)
 

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -160,6 +160,8 @@ class MetadataBase(ModelBase):
     Validates that all classes inheriting from Metadata
     define all the required fields.
 
+    An optional `filter_fields_order` defines the order in which right sidebar
+    filter fields are displayed.
     """
     def __new__(cls, name, bases, attrs):
         if name != 'NewBase' and name != 'Metadata':
@@ -173,12 +175,24 @@ class MetadataBase(ModelBase):
                                 'class on %s' % name)
 
             filter_fields = getattr(phase_config, 'filter_fields', None)
-            searchable_fields = getattr(phase_config, 'searchable_fields', None)
+            searchable_fields = getattr(
+                    phase_config, 'searchable_fields', None)
             column_fields = getattr(phase_config, 'column_fields', None)
+            filter_fields_order = getattr(
+                    phase_config, 'filter_fields_order', None)
 
             if not all((filter_fields, searchable_fields, column_fields)):
                 raise TypeError('Your "PhaseConfig" definition is incorrect '
                                 'on %s. Please check the doc' % name)
+
+            if filter_fields_order:
+                if not set(filter_fields) <= set(filter_fields_order):
+                    raise TypeError(
+                            'Your "PhaseConfig" definition is incorrect '
+                            '"filter_fields_order" should contain the same '
+                            'elements as "filter_fields" and the base'
+                            ' visible fields from'
+                            ' "documents.forms.BaseDocumentFilterForm"')
 
         return super(MetadataBase, cls).__new__(cls, name, bases, attrs)
 

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -148,7 +148,6 @@ class DocumentList(BaseDocumentList):
         context = super(DocumentList, self).get_context_data(**kwargs)
         model = context['object_list'].model
         FilterForm = filterform_factory(model)
-
         qs = self.get_queryset()
         download_form = DocumentDownloadForm(queryset=qs)
 


### PR DESCRIPTION
A new optional PhaseConfig item allows to define
the order in which filter fields appear in sidebar.
Chosing this approach avoid to break the application.