### PR TITLE
Cleanup selected documents upon search query

### DIFF
--- a/src/static/js/documents/routers.js
+++ b/src/static/js/documents/routers.js
@@ -43,7 +43,7 @@ var Phase = Phase || {};
                 collection: this.documentsCollection,
                 favorites: this.favoriteCollection
             });
-            this.navbarView = new Phase.Views.NavbarView();
+            this.navbarView = new Phase.Views.NavbarView({ search: this.search });
             this.progressView = new Phase.Views.ProgressView({ model: this.taskProgress });
             this.searchView = new Phase.Views.SearchView({ model: this.search });
             this.paginationView = new Phase.Views.PaginationView();

--- a/src/static/js/documents/views.js
+++ b/src/static/js/documents/views.js
@@ -241,6 +241,7 @@ var Phase = Phase || {};
             this.listenTo(dispatcher, 'onRowSelected', this.rowSelected);
             this.listenTo(dispatcher, 'onDocumentsFetched', this.renderResults);
             this.listenTo(dispatcher, 'onModalFormSubmitted', this.batchActionModalProcess);
+            this.listenTo(options.search, 'change', this.cleanupSelection);
         },
         configureForm: function() {
             // Prevent closing dropdown on any click
@@ -276,6 +277,11 @@ var Phase = Phase || {};
                 input = this.actionForm.find(input_id);
                 input.remove();
             }
+        },
+        // Un-select all selected rows
+        cleanupSelection: function() {
+            var inputs = this.actionForm.find('input[name=document_ids]');
+            inputs.remove();
         },
         showSearchForm: function() {
             dispatcher.trigger('onSearchFormDisplayed');


### PR DESCRIPTION
Bug fix: when documents were selected in the document list, and a search
filter was applied, the selection was not reset even though the
documents disappeared from the active list.

Fixes #143