### PR TITLE
Use an inmutable id for revisions

### DIFF
--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -438,7 +438,7 @@ class MetadataRevision(models.Model):
 
     @property
     def unique_id(self):
-        return '{}_{}'.format(self.document.document_key, self.name)
+        return self.id
 
     def to_json(self):
         """Converts the revision to a json representation.


### PR DESCRIPTION
Since de revision es id depends on the document number, we met indexing
problems when renaming documents before deleting them.

Fixes #190