### PR TITLE
Internal review

### DIFF
--- a/src/default_documents/migrations/0019_contractordeliverablerevision_internal_review.py
+++ b/src/default_documents/migrations/0019_contractordeliverablerevision_internal_review.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0018_auto_20160111_1400'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contractordeliverablerevision',
+            name='internal_review',
+            field=models.BooleanField(default=False, verbose_name='Internal review only?'),
+        ),
+    ]

--- a/src/transmittals/forms.py
+++ b/src/transmittals/forms.py
@@ -7,7 +7,7 @@ from documents.forms.utils import DocumentDownloadForm
 from django.utils.translation import ugettext_lazy as _
 from crispy_forms.layout import Layout, Field
 
-from default_documents.layout import DocumentFieldset, DateField
+from default_documents.layout import DocumentFieldset, DateField, YesNoLayout
 
 from documents.forms.models import GenericBaseDocumentForm
 from reviews.forms import ReviewFormMixin
@@ -125,10 +125,16 @@ class TransmittableFormMixin(ReviewFormMixin):
 
     def get_trs_layout(self):
         if self.read_only:
-            layout = (DocumentFieldset(
-                _('Outgoing Transmittal'),
-                OutgoingTrsLayout(),
-            ),)
+            layout = (
+                DocumentFieldset(
+                    _('Outgoing Transmittal'),
+                    'internal_review',
+                    OutgoingTrsLayout(),
+                ),)
         else:
-            layout = tuple()
+            layout = (
+                DocumentFieldset(
+                    _('Outgoing Transmittal'),
+                    'internal_review',
+                ),)
         return layout

--- a/src/transmittals/forms.py
+++ b/src/transmittals/forms.py
@@ -7,7 +7,7 @@ from documents.forms.utils import DocumentDownloadForm
 from django.utils.translation import ugettext_lazy as _
 from crispy_forms.layout import Layout, Field
 
-from default_documents.layout import DocumentFieldset, DateField, YesNoLayout
+from default_documents.layout import DocumentFieldset, DateField
 
 from documents.forms.models import GenericBaseDocumentForm
 from reviews.forms import ReviewFormMixin

--- a/src/transmittals/models.py
+++ b/src/transmittals/models.py
@@ -682,6 +682,10 @@ class TransmittableMixin(ReviewMixin):
         null=True, blank=True)
     internal_review = models.BooleanField(
         _('Internal review only?'),
+        choices=Choices(
+            (False, 'No'),
+            (True, 'Yes')
+        ),
         default=False,
     )
 

--- a/src/transmittals/models.py
+++ b/src/transmittals/models.py
@@ -703,6 +703,7 @@ class TransmittableMixin(ReviewMixin):
         """Is this rev ready to be embedded in an outgoing trs?"""
         return all((
             bool(self.review_end_date),
+            not self.internal_review,
             not self.transmittal,
             self.document.current_revision == self.revision))
 

--- a/src/transmittals/models.py
+++ b/src/transmittals/models.py
@@ -680,6 +680,10 @@ class TransmittableMixin(ReviewMixin):
         verbose_name=_('Under preparation by'),
         related_name='+',
         null=True, blank=True)
+    internal_review = models.BooleanField(
+        _('Internal review only?'),
+        default=False,
+    )
 
     class Meta:
         abstract = True


### PR DESCRIPTION
It's now possible to exclude a single revision from the list of transmittable documents.