### PR TITLE
Optional review

### DIFF
--- a/src/transmittals/models.py
+++ b/src/transmittals/models.py
@@ -729,7 +729,6 @@ class TransmittableMixin(ReviewMixin):
     def can_be_transmitted(self):
         """Is this rev ready to be embedded in an outgoing trs?"""
         return all((
-            bool(self.review_end_date),
             not self.internal_review,
             not self.transmittal,
             self.document.current_revision == self.revision))

--- a/src/transmittals/models.py
+++ b/src/transmittals/models.py
@@ -16,6 +16,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.core.files.base import ContentFile
+from django.utils.functional import cached_property
 from django.utils import timezone
 
 from model_utils import Choices
@@ -724,6 +725,18 @@ class TransmittableMixin(ReviewMixin):
         else:
             rc = ''
         return rc
+
+    @cached_property
+    def can_be_reviewed(self):
+        """Can this revision be reviewed.
+
+        A revision that was already embedded in a transmittal cannot
+        be reviewed anymore.
+
+        """
+        return all((
+            super(TransmittableMixin, self).can_be_transmitted,
+            not self.transmittal))
 
     @property
     def can_be_transmitted(self):

--- a/src/transmittals/tests/test_utils.py
+++ b/src/transmittals/tests/test_utils.py
@@ -76,10 +76,10 @@ class TransmittalCreationTests(ContractorDeliverableTestCase):
     def test_create_trs_with_unreviewed_revisions(self):
         """Revisions must have been reviewed to be transmittable."""
         revisions = self.create_docs(transmittable=False)
-        with self.assertRaises(errors.InvalidRevisionsError):
-            create_transmittal(
-                self.category, self.dst_category, revisions, 'FAC10005',
-                self.entity)
+        doc, trs, trs_rev = create_transmittal(
+            self.category, self.dst_category, revisions, 'FAC10005',
+            self.entity)
+        self.assertIsNotNone(trs)
 
     def test_create_trs_with_invalid_from_category(self):
         """Source category must contain transmittable documents."""


### PR DESCRIPTION
on peut créer des transmittal sans passer par l'étape de revue préalable.