### PR TITLE
Add outgoing transmittals pdf customization

### DIFF
--- a/docs/customizing_reports.rst
+++ b/docs/customizing_reports.rst
@@ -1,0 +1,25 @@
+Customizing reports
+===================
+
+Phase outgoing transmittals reorts are generated with Reportlab package.
+Reports work out of the box but can be completely customized.
+
+Company logo
+------------
+
+A company logo can be added on the outgoing transmittals pdf
+on a per organisation basis by writing logo settings on this pattern: COMPANY_LOGO_XXX where XXX is the organisation trigram.
+The logo appears on first page.
+This setting is a dict and must define a path to the logo image file and optionally a wanted_height, logo_x and logo_y in mm.
+logo_x and logo_y define logo coordinates
+The logo aspect ratio is preserved.
+
+
+Report templates
+----------------
+
+There is no templating mechanisme per se, but simple class defining pdf content and layout.
+The base class is transmittals.pdf.BaseTransmittalPdf.
+It can be overriden by subclassing it in a module, on a per organisation basis.
+Then, this custom pdf generator is referenced in TRANSMITTALS_PDF_GENERATOR_XXX settings
+which will provide the dotted path to it, where XXX is the organisation trigramm defined in db.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@ Welcome to Phase's documentation!
    getting_started.rst
    usage.rst
    customizing.rst
+   customizing_reports.rst
    deployment.rst
    cron.rst
    transmittals.rst


### PR DESCRIPTION
Transmittals pdf can be customized by on a per organisation basis:

* adding a logo and its size and layout options defined in settings
* providing a dotted path to a custom pdf generator subclassing a base class

Documentation updated accordingly.