### PR TITLE
Fix reviewers deletion problem

### DIFF
--- a/src/accounts/forms/widgets.py
+++ b/src/accounts/forms/widgets.py
@@ -47,9 +47,10 @@ class MultipleUserAutocomplete(BaseUserAutocomplete):
 
     def render(self, name, value, attrs=None):
         value = value or []
-        objects = self.choices.queryset.filter(pk__in=value)
+        objects = self.choices.queryset.filter(pk__in=value)\
+            .values_list('id', 'name')
         attrs.update({
-            'data-initial-id': '[%s]' % ','.join(unicode(val) for val in value),
-            'data-initial-label': '[%s]' % ','.join('"%s"' % obj for obj in objects),
+            'data-initial-id': '[%s]' % ','.join(unicode(obj[0]) for obj in objects),
+            'data-initial-label': '[%s]' % ','.join('"%s"' % obj[1] for obj in objects),
         })
         return super(AutocompleteTextInput, self).render(name, value, attrs)


### PR DESCRIPTION
The reviewers selectize widget is populated by a django widget.
The values list came from a list whereas the labels were retrieved from a queryset. The orderings of those iterables  were likely to be different, resulting in deletion bug, bcause user could delete one user when thinking he was deleting an other one.

Now both values and labels lists are coming from the queryset.