### PR TITLE
 Display one notification when an export is about to beeing processed

### DIFF
--- a/src/documents/tests/test_forms.py
+++ b/src/documents/tests/test_forms.py
@@ -221,8 +221,9 @@ class DocumentCreateTest(TestCase):
         metadata = document.metadata
         related = list(metadata.related_documents.all())
         self.assertEqual(len(related), 2)
-        self.assertEqual(related[0].metadata.title, "HAZOP related 1")
-        self.assertEqual(related[1].metadata.title, "HAZOP related 2")
+        related_titles = (related[0].metadata.title, related[1].metadata.title)
+        self.assertTrue("HAZOP related 1" in related_titles)
+        self.assertTrue("HAZOP related 2" in related_titles)
 
 
 class DocumentEditTest(TestCase):

--- a/src/exports/tasks.py
+++ b/src/exports/tasks.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
 from core.celery import app
-from notifications.models import notify
 
 
 @app.task
@@ -33,8 +31,3 @@ def process_export(export_id):
     export.write_file()
     export.status = 'done'
     export.save()
-
-    url = export.get_absolute_url()
-    message = _('The export <a href="{}">you required for category {} is ready</a>.'.format(
-        url, export.category))
-    notify(export.owner, message)

--- a/src/exports/views.py
+++ b/src/exports/views.py
@@ -61,8 +61,8 @@ class ExportCreate(LoginRequiredMixin, DocumentListMixin, UpdateView):
     def form_valid(self, form):
         return_value = super(ExportCreate, self).form_valid(form)
         self.object.start_export()
-        message = _('Your export will be processed soon. We will let you know'
-                    ' as soon as it\'s ready.')
+        message = _("Your export is being processed and will be available "
+                    "soon.")
         notify(self.object.owner, message)
         return return_value
 


### PR DESCRIPTION
 Only one notification is displayed when the process export begins.
 The message content has been updated.