### PR TITLE
Add a specific contract model 

### DIFF
--- a/src/categories/admin.py
+++ b/src/categories/admin.py
@@ -6,7 +6,7 @@ from django.forms.models import BaseInlineFormSet
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
 
-from .models import Organisation, CategoryTemplate, Category
+from .models import Organisation, CategoryTemplate, Category, Contract
 from .admin_forms import CategoryTemplateAdminForm
 
 
@@ -63,6 +63,11 @@ class UserCategoryInline(admin.StackedInline):
     formset = RequiredInlineFormSet
 
 
+class ContractAdmin(admin.ModelAdmin):
+    list_display = ('number', 'name')
+
+
 admin.site.register(Organisation, OrganisationAdmin)
 admin.site.register(CategoryTemplate, CategoryTemplateAdmin)
 admin.site.register(Category, CategoryAdmin)
+admin.site.register(Contract, ContractAdmin)

--- a/src/categories/admin.py
+++ b/src/categories/admin.py
@@ -64,8 +64,13 @@ class UserCategoryInline(admin.StackedInline):
 
 
 class ContractAdmin(admin.ModelAdmin):
-    list_display = ('number', 'name')
+    list_display = ('number', 'name', 'get_associated_categories')
 
+    def get_associated_categories(self, obj):
+        categories = obj.categories.all()
+        return ", ".join([c.name for c in categories])
+
+    get_associated_categories.short_description = _('Categories')
 
 admin.site.register(Organisation, OrganisationAdmin)
 admin.site.register(CategoryTemplate, CategoryTemplateAdmin)

--- a/src/categories/factories.py
+++ b/src/categories/factories.py
@@ -7,7 +7,7 @@ from factory import fuzzy
 from django.contrib.contenttypes.models import ContentType
 
 from default_documents.models import DemoMetadata
-from .models import Organisation, CategoryTemplate, Category
+from .models import Organisation, CategoryTemplate, Category, Contract
 
 
 class OrganisationFactory(factory.DjangoModelFactory):
@@ -53,3 +53,22 @@ class CategoryFactory(factory.DjangoModelFactory):
             # A list of groups were passed in, use them
             for entity in extracted:
                 self.third_parties.add(entity)
+
+
+class ContractFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Contract
+
+    number = factory.Sequence(lambda n: 'CONTRACTNB-{0}'.format(n))
+    name = factory.Sequence(lambda n: 'CONTRACTNAME-{0}'.format(n))
+
+    @factory.post_generation
+    def categories(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of groups were passed in, use them
+            for cat in extracted:
+                self.categories.add(cat)

--- a/src/categories/migrations/0009_contract.py
+++ b/src/categories/migrations/0009_contract.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('categories', '0008_auto_20151127_1124'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Contract',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('number', models.CharField(max_length=50, verbose_name='Number')),
+                ('name', models.CharField(max_length=255, verbose_name='Name')),
+                ('categories', models.ManyToManyField(related_name='contracts', verbose_name='Categories', to='categories.Category')),
+            ],
+        ),
+    ]

--- a/src/categories/migrations/0010_auto_20160202_1624.py
+++ b/src/categories/migrations/0010_auto_20160202_1624.py
@@ -7,7 +7,11 @@ from django.db import migrations
 def copy_contracts_from_values_list(apps, schema_editor):
     ValuesList = apps.get_model("metadata", "ValuesList")
     Contract = apps.get_model("categories", "Contract")
-    value_list = ValuesList.objects.filter(index='CONTRACT_NBS').get()
+    try:
+        value_list = ValuesList.objects.filter(index='CONTRACT_NBS').get()
+    except ValuesList.DoesNotExist:
+        return
+    
     for contract in value_list.values.all():
         Contract.objects.create(number=contract.index, name=contract.value)
 

--- a/src/categories/migrations/0010_auto_20160202_1624.py
+++ b/src/categories/migrations/0010_auto_20160202_1624.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def copy_contracts_from_values_list(apps, schema_editor):
+    ValuesList = apps.get_model("metadata", "ValuesList")
+    Contract = apps.get_model("categories", "Contract")
+    value_list = ValuesList.objects.filter(index='CONTRACT_NBS').get()
+    for contract in value_list.values.all():
+        Contract.objects.create(number=contract.index, name=contract.value)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('metadata', '0002_return_code_values'),
+        ('categories', '0009_contract'),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_contracts_from_values_list)
+    ]

--- a/src/categories/migrations/0010_auto_20160202_1624.py
+++ b/src/categories/migrations/0010_auto_20160202_1624.py
@@ -11,7 +11,7 @@ def copy_contracts_from_values_list(apps, schema_editor):
         value_list = ValuesList.objects.filter(index='CONTRACT_NBS').get()
     except ValuesList.DoesNotExist:
         return
-    
+
     for contract in value_list.values.all():
         Contract.objects.create(number=contract.index, name=contract.value)
 

--- a/src/categories/models.py
+++ b/src/categories/models.py
@@ -163,3 +163,14 @@ class Category(models.Model):
             self.organisation.slug,
             self.category_template.slug))
         return url
+
+
+class Contract(models.Model):
+    number = models.CharField(_('Number'), max_length=50)
+    name = models.CharField(_('Name'), max_length=255)
+    categories = models.ManyToManyField(Category,
+                                        related_name='contracts',
+                                        verbose_name=_('Categories'))
+
+    def __unicode__(self):
+        return self.number

--- a/src/default_documents/migrations/0022_auto_20160203_1150.py
+++ b/src/default_documents/migrations/0022_auto_20160203_1150.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.files.storage
+import documents.fileutils
+import documents.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0021_auto_20160122_1131'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contractordeliverablerevision',
+            name='native_file',
+            field=documents.fields.RevisionFileField(upload_to=documents.fileutils.revision_file_path, storage=django.core.files.storage.FileSystemStorage(base_url='/private/', location='/Users/laurentpaoletti/Documents/DEV/DJ/phase/private'), max_length=255, blank=True, null=True, verbose_name='Native File'),
+        ),
+        migrations.AlterField(
+            model_name='correspondencerevision',
+            name='native_file',
+            field=documents.fields.RevisionFileField(upload_to=documents.fileutils.revision_file_path, storage=django.core.files.storage.FileSystemStorage(base_url='/private/', location='/Users/laurentpaoletti/Documents/DEV/DJ/phase/private'), max_length=255, blank=True, null=True, verbose_name='Native File'),
+        ),
+        migrations.AlterField(
+            model_name='demometadatarevision',
+            name='native_file',
+            field=documents.fields.RevisionFileField(upload_to=documents.fileutils.revision_file_path, storage=django.core.files.storage.FileSystemStorage(base_url='/private/', location='/Users/laurentpaoletti/Documents/DEV/DJ/phase/private'), max_length=255, blank=True, null=True, verbose_name='Native File'),
+        ),
+        migrations.AlterField(
+            model_name='minutesofmeetingrevision',
+            name='native_file',
+            field=documents.fields.RevisionFileField(upload_to=documents.fileutils.revision_file_path, storage=django.core.files.storage.FileSystemStorage(base_url='/private/', location='/Users/laurentpaoletti/Documents/DEV/DJ/phase/private'), max_length=255, blank=True, null=True, verbose_name='Native File'),
+        ),
+    ]

--- a/src/default_documents/migrations/0023_contractordeliverable_contract_number_new.py
+++ b/src/default_documents/migrations/0023_contractordeliverable_contract_number_new.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0022_auto_20160203_1150'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contractordeliverable',
+            name='contract_number_new',
+            field=models.CharField(default='XYZ', max_length=50, verbose_name='Contract Number'),
+            preserve_default=False,
+        ),
+    ]

--- a/src/default_documents/migrations/0024_auto_20160203_1207.py
+++ b/src/default_documents/migrations/0024_auto_20160203_1207.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def copy_contracts_numbers(apps, schema_editor):
+    ContractorDeliverable = apps.get_model('default_documents', 'ContractorDeliverable')
+    for ctd in ContractorDeliverable.objects.all():
+        ctd.contract_number_new = ctd.contract_number
+        ctd.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0023_contractordeliverable_contract_number_new'),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_contracts_numbers),
+    ]

--- a/src/default_documents/migrations/0025_auto_20160203_1218.py
+++ b/src/default_documents/migrations/0025_auto_20160203_1218.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0024_auto_20160203_1207'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='contractordeliverable',
+            unique_together=set([('contract_number_new', 'originator', 'unit', 'discipline', 'document_type', 'sequential_number')]),
+        ),
+    ]

--- a/src/default_documents/migrations/0026_auto_20160203_1218.py
+++ b/src/default_documents/migrations/0026_auto_20160203_1218.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0025_auto_20160203_1218'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='contractordeliverable',
+            old_name='contract_number',
+            new_name='contract_number_old',
+        ),
+    ]

--- a/src/default_documents/migrations/0027_auto_20160203_1220.py
+++ b/src/default_documents/migrations/0027_auto_20160203_1220.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import metadata.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0026_auto_20160203_1218'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contractordeliverable',
+            name='contract_number_old',
+            field=metadata.fields.ConfigurableChoiceField(max_length=15, null=True, verbose_name='Contract Number', list_index='CONTRACT_NBS', blank=True),
+        ),
+        migrations.AlterUniqueTogether(
+            name='contractordeliverable',
+            unique_together=set([('contract_number_old', 'originator', 'unit', 'discipline', 'document_type', 'sequential_number')]),
+        ),
+    ]

--- a/src/default_documents/migrations/0028_auto_20160203_1221.py
+++ b/src/default_documents/migrations/0028_auto_20160203_1221.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0027_auto_20160203_1220'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='contractordeliverable',
+            old_name='contract_number_new',
+            new_name='contract_number',
+        ),
+    ]

--- a/src/default_documents/migrations/0029_auto_20160203_1221.py
+++ b/src/default_documents/migrations/0029_auto_20160203_1221.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0028_auto_20160203_1221'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='contractordeliverable',
+            unique_together=set([('contract_number', 'originator', 'unit', 'discipline', 'document_type', 'sequential_number')]),
+        ),
+    ]

--- a/src/default_documents/migrations/0030_correspondence_contract_number_new.py
+++ b/src/default_documents/migrations/0030_correspondence_contract_number_new.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0029_auto_20160203_1221'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='correspondence',
+            name='contract_number_new',
+            field=models.CharField(default='XYZ', max_length=50, verbose_name='Contract Number'),
+            preserve_default=False,
+        ),
+    ]

--- a/src/default_documents/migrations/0031_auto_20160203_1234.py
+++ b/src/default_documents/migrations/0031_auto_20160203_1234.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def copy_contracts_numbers(apps, schema_editor):
+    Correspondence = apps.get_model('default_documents', 'Correspondence')
+    for corresp in Correspondence.objects.all():
+        corresp.contract_number_new = corresp.contract_number
+        corresp.save()
+        
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0030_correspondence_contract_number_new'),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_contracts_numbers)
+    ]

--- a/src/default_documents/migrations/0032_auto_20160203_1238.py
+++ b/src/default_documents/migrations/0032_auto_20160203_1238.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0031_auto_20160203_1234'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='correspondence',
+            unique_together=set([('contract_number_new', 'originator', 'recipient', 'document_type', 'sequential_number')]),
+        ),
+    ]

--- a/src/default_documents/migrations/0033_auto_20160203_1238.py
+++ b/src/default_documents/migrations/0033_auto_20160203_1238.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0032_auto_20160203_1238'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='correspondence',
+            old_name='contract_number',
+            new_name='contract_number_old',
+        ),
+    ]

--- a/src/default_documents/migrations/0034_auto_20160203_1239.py
+++ b/src/default_documents/migrations/0034_auto_20160203_1239.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import metadata.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0033_auto_20160203_1238'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='correspondence',
+            name='contract_number_old',
+            field=metadata.fields.ConfigurableChoiceField(max_length=8, null=True, verbose_name='Contract Number', list_index='CONTRACT_NBS', blank=True),
+        ),
+    ]

--- a/src/default_documents/migrations/0035_auto_20160203_1239.py
+++ b/src/default_documents/migrations/0035_auto_20160203_1239.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0034_auto_20160203_1239'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='correspondence',
+            unique_together=set([('contract_number_old', 'originator', 'recipient', 'document_type', 'sequential_number')]),
+        ),
+    ]

--- a/src/default_documents/migrations/0036_auto_20160203_1240.py
+++ b/src/default_documents/migrations/0036_auto_20160203_1240.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0035_auto_20160203_1239'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='correspondence',
+            old_name='contract_number_new',
+            new_name='contract_number',
+        ),
+    ]

--- a/src/default_documents/migrations/0037_auto_20160203_1240.py
+++ b/src/default_documents/migrations/0037_auto_20160203_1240.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0036_auto_20160203_1240'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='correspondence',
+            unique_together=set([('contract_number', 'originator', 'recipient', 'document_type', 'sequential_number')]),
+        ),
+    ]

--- a/src/default_documents/migrations/0038_minutesofmeeting_contract_number_new.py
+++ b/src/default_documents/migrations/0038_minutesofmeeting_contract_number_new.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0037_auto_20160203_1240'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='minutesofmeeting',
+            name='contract_number_new',
+            field=models.CharField(default='XYZ', max_length=50, verbose_name='Contract Number'),
+            preserve_default=False,
+        ),
+    ]

--- a/src/default_documents/migrations/0039_auto_20160203_1242.py
+++ b/src/default_documents/migrations/0039_auto_20160203_1242.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def copy_contracts_numbers(apps, schema_editor):
+    MinutesOfMeeting = apps.get_model('default_documents', 'MinutesOfMeeting')
+    for mom in MinutesOfMeeting.objects.all():
+        mom.contract_number_new = mom.contract_number
+        mom.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0038_minutesofmeeting_contract_number_new'),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_contracts_numbers)
+    ]

--- a/src/default_documents/migrations/0040_auto_20160203_1243.py
+++ b/src/default_documents/migrations/0040_auto_20160203_1243.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0039_auto_20160203_1242'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='minutesofmeeting',
+            unique_together=set([('contract_number_new', 'originator', 'recipient', 'document_type', 'sequential_number')]),
+        ),
+    ]

--- a/src/default_documents/migrations/0041_auto_20160203_1243.py
+++ b/src/default_documents/migrations/0041_auto_20160203_1243.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0040_auto_20160203_1243'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='minutesofmeeting',
+            old_name='contract_number',
+            new_name='contract_number_old',
+        ),
+    ]

--- a/src/default_documents/migrations/0042_auto_20160203_1244.py
+++ b/src/default_documents/migrations/0042_auto_20160203_1244.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import metadata.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0041_auto_20160203_1243'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='minutesofmeeting',
+            name='contract_number_old',
+            field=metadata.fields.ConfigurableChoiceField(max_length=8, null=True, verbose_name='Contract Number', list_index='CONTRACT_NBS', blank=True),
+        ),
+    ]

--- a/src/default_documents/migrations/0043_auto_20160203_1245.py
+++ b/src/default_documents/migrations/0043_auto_20160203_1245.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0042_auto_20160203_1244'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='minutesofmeeting',
+            unique_together=set([('contract_number_old', 'originator', 'recipient', 'document_type', 'sequential_number')]),
+        ),
+    ]

--- a/src/default_documents/migrations/0044_auto_20160203_1245.py
+++ b/src/default_documents/migrations/0044_auto_20160203_1245.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0043_auto_20160203_1245'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='minutesofmeeting',
+            old_name='contract_number_new',
+            new_name='contract_number',
+        ),
+    ]

--- a/src/default_documents/migrations/0045_auto_20160203_1245.py
+++ b/src/default_documents/migrations/0045_auto_20160203_1245.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_documents', '0044_auto_20160203_1245'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='minutesofmeeting',
+            unique_together=set([('contract_number', 'originator', 'recipient', 'document_type', 'sequential_number')]),
+        ),
+    ]

--- a/src/default_documents/models.py
+++ b/src/default_documents/models.py
@@ -29,10 +29,14 @@ class ContractorDeliverable(ScheduleMixin, Metadata):
     # General information
     title = models.TextField(
         verbose_name=u"Title")
-    contract_number = ConfigurableChoiceField(
+    contract_number_old = ConfigurableChoiceField(
         verbose_name=u"Contract Number",
         max_length=15,
-        list_index='CONTRACT_NBS')
+        list_index='CONTRACT_NBS', null=True, blank=True)
+    contract_number = models.CharField(
+         verbose_name='Contract Number',
+         max_length=50
+    )
     originator = ConfigurableChoiceField(
         verbose_name=u"Originator",
         default=u"FWF",

--- a/src/default_documents/models.py
+++ b/src/default_documents/models.py
@@ -29,6 +29,7 @@ class ContractorDeliverable(ScheduleMixin, Metadata):
     # General information
     title = models.TextField(
         verbose_name=u"Title")
+    # Let's keep this field for a while
     contract_number_old = ConfigurableChoiceField(
         verbose_name=u"Contract Number",
         max_length=15,
@@ -440,10 +441,14 @@ class Correspondence(Metadata):
     subject = models.TextField(_('Subject'))
     correspondence_date = models.DateField(_('Correspondence date'))
     received_sent_date = models.DateField(_('Received / sent date'))
-    contract_number = ConfigurableChoiceField(
+    contract_number_old = ConfigurableChoiceField(
         _('Contract Number'),
         max_length=8,
-        list_index='CONTRACT_NBS')
+        list_index='CONTRACT_NBS', null=True, blank=True)
+    contract_number = models.CharField(
+         verbose_name='Contract Number',
+         max_length=50
+    )
     originator = ConfigurableChoiceField(
         _('Originator'),
         default='FWF',

--- a/src/default_documents/models.py
+++ b/src/default_documents/models.py
@@ -595,10 +595,15 @@ class MinutesOfMeeting(Metadata):
     subject = models.TextField(_('Subject'))
     meeting_date = models.DateField(_('Meeting date'))
     received_sent_date = models.DateField(_('Received / sent date'))
-    contract_number = ConfigurableChoiceField(
+    # We keep it for a while
+    contract_number_old = ConfigurableChoiceField(
         _('Contract Number'),
         max_length=8,
-        list_index='CONTRACT_NBS')
+        list_index='CONTRACT_NBS', blank=True, null=True)
+    contract_number = models.CharField(
+         verbose_name='Contract Number',
+         max_length=50
+    )
     originator = ConfigurableChoiceField(
         _('Originator'),
         default='FWF',

--- a/src/default_documents/models.py
+++ b/src/default_documents/models.py
@@ -35,9 +35,8 @@ class ContractorDeliverable(ScheduleMixin, Metadata):
         max_length=15,
         list_index='CONTRACT_NBS', null=True, blank=True)
     contract_number = models.CharField(
-         verbose_name='Contract Number',
-         max_length=50
-    )
+        verbose_name='Contract Number',
+        max_length=50)
     originator = ConfigurableChoiceField(
         verbose_name=u"Originator",
         default=u"FWF",
@@ -446,9 +445,8 @@ class Correspondence(Metadata):
         max_length=8,
         list_index='CONTRACT_NBS', null=True, blank=True)
     contract_number = models.CharField(
-         verbose_name='Contract Number',
-         max_length=50
-    )
+        verbose_name='Contract Number',
+        max_length=50)
     originator = ConfigurableChoiceField(
         _('Originator'),
         default='FWF',
@@ -601,8 +599,8 @@ class MinutesOfMeeting(Metadata):
         max_length=8,
         list_index='CONTRACT_NBS', blank=True, null=True)
     contract_number = models.CharField(
-         verbose_name='Contract Number',
-         max_length=50
+        verbose_name='Contract Number',
+        max_length=50
     )
     originator = ConfigurableChoiceField(
         _('Originator'),

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -367,7 +367,7 @@ class MetadataRevision(models.Model):
         verbose_name=u"Revision Date")
     native_file = RevisionFileField(
         verbose_name=u"Native File",
-        null=True, blank=True)
+        null=True, blank=True, max_length=255)
     pdf_file = RevisionFileField(
         verbose_name=u"PDF File",
         null=True, blank=True)

--- a/src/templates/transmittals/document_list_create_transmittal_modal.html
+++ b/src/templates/transmittals/document_list_create_transmittal_modal.html
@@ -36,11 +36,10 @@
 
             <div class="form-group">
                 <label for="contract-number-select">{{ _('Contract Number') }}</label>
-                {% get_values_list 'CONTRACT_NBS' as values %}
                 <select id="contract-number-select" name="contract_number" class="form-control">
-                    {% for index, value in values %}
-                    <option value="{{ index }}">
-                        {{ value }}
+                    {% for contracts in category.contracts.all %}
+                    <option value="{{ contracts.number }}">
+                        {{ contracts.name }}
                     </option>
                     {% endfor %}
                 </select>

--- a/src/transmittals/errors.py
+++ b/src/transmittals/errors.py
@@ -20,3 +20,7 @@ class InvalidCategoryError(TransmittalError):
 
 class InvalidRecipientError(TransmittalError):
     pass
+
+
+class InvalidContractNumberError(TransmittalError):
+    pass

--- a/src/transmittals/migrations/0021_outgoingtransmittal_contract_number_new.py
+++ b/src/transmittals/migrations/0021_outgoingtransmittal_contract_number_new.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0020_auto_20160112_0941'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='outgoingtransmittal',
+            name='contract_number_new',
+            field=models.CharField(default='XYZ', max_length=50, verbose_name='Contract Number'),
+            preserve_default=False,
+        ),
+    ]

--- a/src/transmittals/migrations/0022_auto_20160202_1833.py
+++ b/src/transmittals/migrations/0022_auto_20160202_1833.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def copy_contracts_numbers(apps, schema_editor):
+    OutgoingTransmittal = apps.get_model('transmittals', 'OutgoingTransmittal')
+    for otg in OutgoingTransmittal.objects.all():
+        otg.contract_number_new = otg.contract_number_new
+        otg.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0021_outgoingtransmittal_contract_number_new'),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_contracts_numbers),
+    ]

--- a/src/transmittals/migrations/0023_auto_20160202_1837.py
+++ b/src/transmittals/migrations/0023_auto_20160202_1837.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0022_auto_20160202_1833'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='outgoingtransmittal',
+            old_name='contract_number',
+            new_name='contract_number_old',
+        ),
+    ]

--- a/src/transmittals/migrations/0024_auto_20160202_1838.py
+++ b/src/transmittals/migrations/0024_auto_20160202_1838.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0023_auto_20160202_1837'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='outgoingtransmittal',
+            old_name='contract_number_new',
+            new_name='contract_number',
+        ),
+    ]

--- a/src/transmittals/migrations/0025_auto_20160202_1856.py
+++ b/src/transmittals/migrations/0025_auto_20160202_1856.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import metadata.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0024_auto_20160202_1838'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='outgoingtransmittal',
+            name='contract_number_old',
+            field=metadata.fields.ConfigurableChoiceField(max_length=8, null=True, verbose_name='Contract Number', list_index='CONTRACT_NBS', blank=True),
+        ),
+    ]

--- a/src/transmittals/migrations/0026_transmittal_contract_number_new.py
+++ b/src/transmittals/migrations/0026_transmittal_contract_number_new.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0025_auto_20160202_1856'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='transmittal',
+            name='contract_number_new',
+            field=models.CharField(default='XYZ', max_length=50, verbose_name='Contract Number'),
+            preserve_default=False,
+        ),
+    ]

--- a/src/transmittals/migrations/0027_auto_20160203_1004.py
+++ b/src/transmittals/migrations/0027_auto_20160203_1004.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0026_transmittal_contract_number_new'),
+    ]
+
+    operations = [
+        migrations.AlterIndexTogether(
+            name='transmittal',
+            index_together=set([('originator', 'recipient', 'sequential_number', 'status')]),
+        ),
+    ]

--- a/src/transmittals/migrations/0028_auto_20160203_1004.py
+++ b/src/transmittals/migrations/0028_auto_20160203_1004.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0027_auto_20160203_1004'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='transmittal',
+            old_name='contract_number',
+            new_name='contract_number_old',
+        ),
+    ]

--- a/src/transmittals/migrations/0029_auto_20160203_1005.py
+++ b/src/transmittals/migrations/0029_auto_20160203_1005.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0028_auto_20160203_1004'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='transmittal',
+            old_name='contract_number_new',
+            new_name='contract_number',
+        ),
+    ]

--- a/src/transmittals/migrations/0030_auto_20160203_1005.py
+++ b/src/transmittals/migrations/0030_auto_20160203_1005.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0029_auto_20160203_1005'),
+    ]
+
+    operations = [
+        migrations.AlterIndexTogether(
+            name='transmittal',
+            index_together=set([('contract_number', 'originator', 'recipient', 'sequential_number', 'status')]),
+        ),
+    ]

--- a/src/transmittals/migrations/0031_trsrevision_contract_number_new.py
+++ b/src/transmittals/migrations/0031_trsrevision_contract_number_new.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0030_auto_20160203_1005'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='trsrevision',
+            name='contract_number_new',
+            field=models.CharField(default='XYZ', max_length=50, verbose_name='Contract Number'),
+            preserve_default=False,
+        ),
+    ]

--- a/src/transmittals/migrations/0032_auto_20160203_1040.py
+++ b/src/transmittals/migrations/0032_auto_20160203_1040.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def copy_contracts_numbers(apps, schema_editor):
+    Transmittal = apps.get_model('transmittals', 'Transmittal')
+    for otg in Transmittal.objects.all():
+        otg.contract_number = otg.contract_number_old
+        otg.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0031_trsrevision_contract_number_new'),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_contracts_numbers)
+    ]
+

--- a/src/transmittals/migrations/0033_auto_20160203_1055.py
+++ b/src/transmittals/migrations/0033_auto_20160203_1055.py
@@ -5,8 +5,8 @@ from django.db import migrations, models
 
 
 def copy_contracts_numbers(apps, schema_editor):
-    OutgoingTransmittal = apps.get_model('transmittals', 'OutgoingTransmittal')
-    for otg in OutgoingTransmittal.objects.all():
+    TrsRevision = apps.get_model('transmittals', 'TrsRevision')
+    for otg in TrsRevision.objects.all():
         otg.contract_number_new = otg.contract_number
         otg.save()
 
@@ -14,7 +14,7 @@ def copy_contracts_numbers(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('transmittals', '0021_outgoingtransmittal_contract_number_new'),
+        ('transmittals', '0032_auto_20160203_1040'),
     ]
 
     operations = [

--- a/src/transmittals/migrations/0034_auto_20160203_1058.py
+++ b/src/transmittals/migrations/0034_auto_20160203_1058.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0033_auto_20160203_1055'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='trsrevision',
+            old_name='contract_number',
+            new_name='contract_number_old',
+        ),
+    ]

--- a/src/transmittals/migrations/0035_auto_20160203_1058.py
+++ b/src/transmittals/migrations/0035_auto_20160203_1058.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0034_auto_20160203_1058'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='trsrevision',
+            old_name='contract_number_new',
+            new_name='contract_number',
+        ),
+    ]

--- a/src/transmittals/migrations/0036_auto_20160203_1108.py
+++ b/src/transmittals/migrations/0036_auto_20160203_1108.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import metadata.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0035_auto_20160203_1058'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='transmittal',
+            name='contract_number_old',
+            field=metadata.fields.ConfigurableChoiceField(max_length=8, null=True, verbose_name='Contract Number', list_index='CONTRACT_NBS', blank=True),
+        ),
+    ]

--- a/src/transmittals/migrations/0037_auto_20160203_1108.py
+++ b/src/transmittals/migrations/0037_auto_20160203_1108.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import metadata.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0036_auto_20160203_1108'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='trsrevision',
+            name='contract_number_old',
+            field=metadata.fields.ConfigurableChoiceField(max_length=8, null=True, verbose_name='Contract Number', list_index='CONTRACT_NBS', blank=True),
+        ),
+    ]

--- a/src/transmittals/migrations/0038_auto_20160203_1123.py
+++ b/src/transmittals/migrations/0038_auto_20160203_1123.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.files.storage
+import transmittals.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0037_auto_20160203_1108'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='trsrevision',
+            name='native_file',
+            field=transmittals.fields.TransmittalFileField(upload_to=transmittals.fields.transmittal_upload_to, storage=django.core.files.storage.FileSystemStorage(base_url='/private/', location='/Users/laurentpaoletti/Documents/DEV/DJ/phase/private'), max_length=255, blank=True, null=True, verbose_name='Native file'),
+        ),
+    ]

--- a/src/transmittals/migrations/0039_auto_20160203_1150.py
+++ b/src/transmittals/migrations/0039_auto_20160203_1150.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.files.storage
+import documents.fileutils
+import documents.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0038_auto_20160203_1123'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='outgoingtransmittalrevision',
+            name='native_file',
+            field=documents.fields.RevisionFileField(upload_to=documents.fileutils.revision_file_path, storage=django.core.files.storage.FileSystemStorage(base_url='/private/', location='/Users/laurentpaoletti/Documents/DEV/DJ/phase/private'), max_length=255, blank=True, null=True, verbose_name='Native File'),
+        ),
+        migrations.AlterField(
+            model_name='transmittalrevision',
+            name='native_file',
+            field=documents.fields.RevisionFileField(upload_to=documents.fileutils.revision_file_path, storage=django.core.files.storage.FileSystemStorage(base_url='/private/', location='/Users/laurentpaoletti/Documents/DEV/DJ/phase/private'), max_length=255, blank=True, null=True, verbose_name='Native File'),
+        ),
+    ]

--- a/src/transmittals/models.py
+++ b/src/transmittals/models.py
@@ -399,7 +399,7 @@ class TrsRevision(models.Model):
         verbose_name=_('Pdf file'))
     native_file = TransmittalFileField(
         verbose_name=_('Native file'),
-        null=True, blank=True)
+        null=True, blank=True, max_length=255)
 
     class Meta:
         app_label = 'transmittals'

--- a/src/transmittals/models.py
+++ b/src/transmittals/models.py
@@ -70,7 +70,9 @@ class Transmittal(Metadata):
     contract_number_old = ConfigurableChoiceField(
         verbose_name='Contract Number',
         max_length=8,
-        list_index='CONTRACT_NBS')
+        list_index='CONTRACT_NBS',
+        null=True,
+        blank=True)
     contract_number = models.CharField(
          verbose_name='Contract Number',
          max_length=50
@@ -286,12 +288,19 @@ class TrsRevision(models.Model):
     is_new_revision = models.BooleanField(
         _('Is new revision?'))
 
+    # We'll keep it for a while.
     # Those are fields that will one day be configurable
     # but are static for now.
-    contract_number = ConfigurableChoiceField(
+    contract_number_old = ConfigurableChoiceField(
         verbose_name='Contract Number',
         max_length=8,
-        list_index='CONTRACT_NBS')
+        list_index='CONTRACT_NBS',
+        null=True,
+        blank=True)
+    contract_number = models.CharField(
+         verbose_name='Contract Number',
+         max_length=50
+    )
     originator = ConfigurableChoiceField(
         _('Originator'),
         default='FWF',

--- a/src/transmittals/models.py
+++ b/src/transmittals/models.py
@@ -74,9 +74,8 @@ class Transmittal(Metadata):
         null=True,
         blank=True)
     contract_number = models.CharField(
-         verbose_name='Contract Number',
-         max_length=50
-    )
+        verbose_name='Contract Number',
+        max_length=50)
     originator = ConfigurableChoiceField(
         _('Originator'),
         default='CTR',
@@ -298,9 +297,8 @@ class TrsRevision(models.Model):
         null=True,
         blank=True)
     contract_number = models.CharField(
-         verbose_name='Contract Number',
-         max_length=50
-    )
+        verbose_name='Contract Number',
+        max_length=50)
     originator = ConfigurableChoiceField(
         _('Originator'),
         default='FWF',
@@ -495,9 +493,8 @@ class OutgoingTransmittal(Metadata):
         blank=True
     )
     contract_number = models.CharField(
-         verbose_name='Contract Number',
-         max_length=50
-    )
+        verbose_name='Contract Number',
+        max_length=50)
     originator = models.CharField(
         _('Originator'),
         max_length=3)

--- a/src/transmittals/models.py
+++ b/src/transmittals/models.py
@@ -472,10 +472,17 @@ class OutgoingTransmittal(Metadata):
         'categories.Category',
         verbose_name=_('From category'),
         on_delete=models.PROTECT)
-    contract_number = ConfigurableChoiceField(
+    contract_number_old = ConfigurableChoiceField(
         verbose_name='Contract Number',
         max_length=8,
-        list_index='CONTRACT_NBS')
+        list_index='CONTRACT_NBS',
+        null=True,
+        blank=True
+    )
+    contract_number = models.CharField(
+         verbose_name='Contract Number',
+         max_length=50
+    )
     originator = models.CharField(
         _('Originator'),
         max_length=3)

--- a/src/transmittals/models.py
+++ b/src/transmittals/models.py
@@ -66,10 +66,15 @@ class Transmittal(Metadata):
     ack_of_receipt_date = models.DateField(
         _('Acknowledgment of receipt date'),
         null=True, blank=True)
-    contract_number = ConfigurableChoiceField(
+    # We'll keep it for a while
+    contract_number_old = ConfigurableChoiceField(
         verbose_name='Contract Number',
         max_length=8,
         list_index='CONTRACT_NBS')
+    contract_number = models.CharField(
+         verbose_name='Contract Number',
+         max_length=50
+    )
     originator = ConfigurableChoiceField(
         _('Originator'),
         default='CTR',
@@ -472,6 +477,7 @@ class OutgoingTransmittal(Metadata):
         'categories.Category',
         verbose_name=_('From category'),
         on_delete=models.PROTECT)
+    # We'll have to delete it, but let's keep this one for a while
     contract_number_old = ConfigurableChoiceField(
         verbose_name='Contract Number',
         max_length=8,

--- a/src/transmittals/tests/test_utils.py
+++ b/src/transmittals/tests/test_utils.py
@@ -40,7 +40,6 @@ class TransmittalCreationTests(ContractorDeliverableTestCase):
 
         self.linked_contract = ContractFactory.create(
             categories=[self.category])
-        self.unlinked_contract = ContractFactory()
 
     def create_docs(self, nb_docs=10, transmittable=True, default_kwargs=None):
         if default_kwargs is None:
@@ -105,8 +104,19 @@ class TransmittalCreationTests(ContractorDeliverableTestCase):
                 self.category, invalid_cat, revisions,
                 self.linked_contract.number, self.entity)
 
-    def test_create_transmittal(self):
+    def test_create_transmittal_with_unlinked_contract(self):
+        """"Contract must be linked to doc category."""
+        revisions = self.create_docs()
+        unlinked_contract = ContractFactory()  # Non linked to the category
+        junk_number = "XYZ"  # This one does not exist in db
+        for contract_number in unlinked_contract.number, junk_number:
+            # Both must fail
+            with self.assertRaises(errors.InvalidContractNumberError):
+                create_transmittal(
+                    self.category, self.dst_category, revisions,
+                    contract_number, self.entity)
 
+    def test_create_transmittal(self):
         revisions = self.create_docs()
         revision = revisions[0]
         self.assertIsNone(revision.transmittal)

--- a/src/transmittals/tests/test_utils.py
+++ b/src/transmittals/tests/test_utils.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 
 from documents.factories import DocumentFactory
 from default_documents.tests.test import ContractorDeliverableTestCase
-from categories.factories import CategoryFactory
+from categories.factories import CategoryFactory, ContractFactory
 from accounts.factories import UserFactory, EntityFactory
 from transmittals.factories import (
     OutgoingTransmittalFactory, OutgoingTransmittalRevisionFactory)
@@ -38,7 +38,13 @@ class TransmittalCreationTests(ContractorDeliverableTestCase):
             password='pass',
             category=self.category)
 
-    def create_docs(self, nb_docs=10, transmittable=True, default_kwargs={}):
+        self.linked_contract = ContractFactory.create(
+            categories=[self.category])
+        self.unlinked_contract = ContractFactory()
+
+    def create_docs(self, nb_docs=10, transmittable=True, default_kwargs=None):
+        if default_kwargs is None:
+            default_kwargs = {}
         doc_kwargs = {
             'revision': {
                 'reviewers': [self.user1],
@@ -62,23 +68,23 @@ class TransmittalCreationTests(ContractorDeliverableTestCase):
         """A trs cannot be created without revisions."""
         with self.assertRaises(errors.MissingRevisionsError):
             create_transmittal(
-                self.category, self.dst_category, [], 'FAC10005',
-                self.entity)
+                self.category, self.dst_category, [],
+                self.linked_contract.number, self.entity)
 
     def test_create_trs_with_invalid_revisions(self):
         """We must check that the given revisions are valid."""
         with self.assertRaises(errors.InvalidRevisionsError):
             revisions = ['toto', 'tata', 'tutu']
             create_transmittal(
-                self.category, self.dst_category, revisions, 'FAC10005',
-                self.entity)
+                self.category, self.dst_category, revisions,
+                self.linked_contract.number, self.entity)
 
     def test_create_trs_with_unreviewed_revisions(self):
         """Revisions must have been reviewed to be transmittable."""
         revisions = self.create_docs(transmittable=False)
         doc, trs, trs_rev = create_transmittal(
-            self.category, self.dst_category, revisions, 'FAC10005',
-            self.entity)
+            self.category, self.dst_category, revisions,
+            self.linked_contract.number, self.entity)
         self.assertIsNotNone(trs)
 
     def test_create_trs_with_invalid_from_category(self):
@@ -87,8 +93,8 @@ class TransmittalCreationTests(ContractorDeliverableTestCase):
         revisions = self.create_docs()
         with self.assertRaises(errors.InvalidCategoryError):
             create_transmittal(
-                invalid_cat, self.dst_category, revisions, 'FAC10005',
-                self.entity)
+                invalid_cat, self.dst_category, revisions,
+                self.linked_contract.number, self.entity)
 
     def test_create_trs_with_invalid_dest_category(self):
         """Destination category must contain outgoing transmittals."""
@@ -96,17 +102,18 @@ class TransmittalCreationTests(ContractorDeliverableTestCase):
         revisions = self.create_docs()
         with self.assertRaises(errors.InvalidCategoryError):
             create_transmittal(
-                self.category, invalid_cat, revisions, 'FAC10005',
-                self.entity)
+                self.category, invalid_cat, revisions,
+                self.linked_contract.number, self.entity)
 
     def test_create_transmittal(self):
+
         revisions = self.create_docs()
         revision = revisions[0]
         self.assertIsNone(revision.transmittal)
 
         doc, trs, trs_rev = create_transmittal(
-            self.category, self.dst_category, revisions, 'FAC10005',
-            self.entity)
+            self.category, self.dst_category, revisions,
+            self.linked_contract.number, self.entity)
         self.assertIsNotNone(trs)
         self.assertTrue(isinstance(trs, OutgoingTransmittal))
         self.assertEqual(trs.revisions_category, self.category)
@@ -128,8 +135,8 @@ class TransmittalCreationTests(ContractorDeliverableTestCase):
         self.assertIsNone(revision.external_review_due_date)
 
         doc, trs, trs_rev = create_transmittal(
-            self.category, self.dst_category, revisions, 'FAC10005',
-            self.entity)
+            self.category, self.dst_category, revisions,
+            self.linked_contract.number, self.entity)
         self.assertIsNotNone(trs)
         revision.refresh_from_db()
         self.assertIsNone(revision.external_review_due_date)
@@ -148,8 +155,8 @@ class TransmittalCreationTests(ContractorDeliverableTestCase):
         self.assertIsNone(revision.external_review_due_date)
 
         doc, trs, trs_rev = create_transmittal(
-            self.category, self.dst_category, revisions, 'FAC10005',
-            self.entity)
+            self.category, self.dst_category, revisions,
+            self.linked_contract.number, self.entity)
         self.assertIsNotNone(trs)
         revision.refresh_from_db()
         self.assertIsNotNone(revision.external_review_due_date)

--- a/src/transmittals/tests/test_validation.py
+++ b/src/transmittals/tests/test_validation.py
@@ -12,7 +12,7 @@ from django.core.cache import cache
 from django.contrib.contenttypes.models import ContentType
 
 from documents.models import Document
-from categories.factories import CategoryFactory
+from categories.factories import CategoryFactory, ContractFactory
 from transmittals.imports import TrsImport
 from transmittals.factories import TransmittalFactory
 from transmittals.models import Transmittal
@@ -36,7 +36,9 @@ class TransmittalsValidationTests(TestCase):
             self.doc_category = document.category
         except Document.DoesNotExist:
             self.doc_category = CategoryFactory()
-
+        contract = ContractFactory.create(number='FAC10005-CTR-CLT-TRS-00001',
+                                          categories=[self.doc_category])
+        self.contract_number = contract.number
         trs_content_type = ContentType.objects.get_for_model(Transmittal)
         self.trs_category = CategoryFactory(category_template__metadata_model=trs_content_type)
 

--- a/src/transmittals/utils.py
+++ b/src/transmittals/utils.py
@@ -79,6 +79,12 @@ def create_transmittal(from_category, to_category, revisions, contract_nb,
         raise errors.InvalidRecipientError(
             'Recipient is not linked to the document category')
 
+    # The 'contract_nb' must belong to the contracts linked by the category
+    cat_contracts = from_category.contracts.values_list('number', flat=True)
+    if contract_nb not in cat_contracts:
+        raise errors.InvalidContractNumberError(
+            'Contract number is not linked to the document category')
+
     # Do we have valid revisions?
     for rev in revisions:
         if not isinstance(rev, TransmittableMixin):


### PR DESCRIPTION
Contracts used to be set as values lists, but this kind of data structure does not convey enough informations to allow filtering (e.g associate contracts with categories and display only relevant contracts when adding or editing documents in a specific category).

Now contracts have their own model and can be associated with categories.