### PR TITLE
Transmittal readonly fields

### DIFF
--- a/src/default_documents/layout.py
+++ b/src/default_documents/layout.py
@@ -104,6 +104,7 @@ class FlatRelatedDocumentsLayout(LayoutObject):
 
 
 class PropertyLayout(LayoutObject):
+    """Display a text value as a fake readonly input."""
 
     html = '''
     <div id="" class="form-group{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
@@ -130,12 +131,25 @@ class PropertyLayout(LayoutObject):
 
     def render(self, form, form_style, context, template_pack=None):
         prop = getattr(form.instance, self.property_name) or ''
+        prop_name = self.property_name
+
+        try:
+            form_field = form.fields[prop_name]
+        except:
+            form_field = None
+
+        try:
+            model_field = form.instance._meta.get_field(prop_name)
+        except:
+            model_field = None
 
         # Get the property label
         if hasattr(prop, 'short_description'):
             name = prop.short_description
-        elif self.property_name in form.fields:
-            name = form.fields[self.property_name].label
+        elif form_field:
+            name = form_field.label
+        elif model_field:
+            name = model_field.verbose_name
         else:
             name = self.property_name
 

--- a/src/documents/urls.py
+++ b/src/documents/urls.py
@@ -32,6 +32,9 @@ urlpatterns = patterns(
     url(r'^(?P<organisation>[\w-]+)/(?P<category>[\w-]+)/(?P<document_key>[\w-]+)/edit/$',
         DocumentEdit.as_view(),
         name="document_edit"),
+    url(r'^(?P<organisation>[\w-]+)/(?P<category>[\w-]+)/(?P<document_key>[\w-]+)/edit/(?P<revision>\d+)/$',
+        DocumentEdit.as_view(),
+        name="document_edit"),
     url(r'^(?P<organisation>[\w-]+)/(?P<category>[\w-]+)/(?P<document_key>[\w-]+)/revise/$',
         DocumentRevise.as_view(),
         name="document_revise"),
@@ -41,7 +44,4 @@ urlpatterns = patterns(
     url(r'^(?P<organisation>[\w-]+)/(?P<category>[\w-]+)/(?P<document_key>[\w-]+)/revision_delete/$',
         DocumentRevisionDelete.as_view(),
         name="document_revision_delete"),
-    url(r'^(?P<organisation>[\w-]+)/(?P<category>[\w-]+)/(?P<document_key>[\w-]+)/edit/(?P<revision>\d+)/$',
-        DocumentEdit.as_view(),
-        name="document_edit"),
 )

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -223,9 +223,8 @@ class DocumentFormMixin(object):
         """Get the edited revision."""
         revision_number = self.kwargs.get('revision', None)
         if revision_number:
-            try:
-                revision = self.object.get_revision(revision_number)
-            except ObjectDoesNotExist:
+            revision = self.object.get_revision(revision_number)
+            if revision is None:
                 raise Http404(_('This revision does not exist'))
         else:
             revision = self.object.latest_revision

--- a/src/transmittals/forms.py
+++ b/src/transmittals/forms.py
@@ -66,31 +66,13 @@ class TransmittalRevisionForm(GenericBaseDocumentForm):
 
 
 class OutgoingTransmittalForm(GenericBaseDocumentForm):
-    def __init__(self, *args, **kwargs):
-        super(OutgoingTransmittalForm, self).__init__(*args, **kwargs)
-        self.setup_originator_field()
+    """Form for outgoing transmittal (duh).
 
-    def setup_originator_field(self):
-        if not self.instance:
-            return
-        # This field is not supposed to be edited so me make it readonly
-        if 'originator' in self.fields:
-            self.fields['originator'].widget.attrs.update({'readonly': True})
+    Since transmittals are not created through this form and sequential numbers
+    are auto-generated, some fields MUST not be edited. Hence, we just
+    display them as properties.
 
-    def setup_contract_number_field(self):
-        # The behavior is different in Outgoing transmittals.
-        # Here, contract numbers must belong to the instance
-        # revisions_category field.
-
-        # OutgoingTransmittal are not supposed to be created from this form
-        if not self.instance:
-            return
-
-        # This field is not supposed to be edited so me make it readonly
-        if 'contract_number' in self.fields:
-            self.fields['contract_number'].widget.attrs.update(
-                {'readonly': True})
-
+    """
     def get_related_documents_layout(self):
         related_documents = DocumentFieldset(
             _('Related documents'),
@@ -103,10 +85,10 @@ class OutgoingTransmittalForm(GenericBaseDocumentForm):
                 _('General information'),
                 Field('document_key', type='hidden'),
                 Field('revisions_category', type='hidden'),
-                'document_number',
-                'contract_number',
-                'originator',
-                'recipient',
+                PropertyLayout('document_number'),
+                PropertyLayout('contract_number'),
+                PropertyLayout('originator'),
+                PropertyLayout('recipient'),
                 Field('sequential_number', type='hidden'),
                 PropertyLayout('get_ack_of_receipt_display'),
                 DateField('ack_of_receipt_date'),
@@ -116,7 +98,9 @@ class OutgoingTransmittalForm(GenericBaseDocumentForm):
 
     class Meta:
         model = OutgoingTransmittal
-        exclude = ('document', 'latest_revision', 'related_documents')
+        exclude = ('document', 'latest_revision', 'related_documents',
+                   'document_number', 'contract_number', 'originator',
+                   'recipient')
 
 
 class OutgoingTransmittalRevisionForm(GenericBaseDocumentForm):

--- a/src/transmittals/utils.py
+++ b/src/transmittals/utils.py
@@ -108,17 +108,24 @@ def create_transmittal(from_category, to_category, revisions, contract_nb,
     sequential_number = find_next_trs_number(originator, recipient, contract_nb)
     form_data.update({
         'revisions_category': from_category.id,
-        'contract_number': contract_nb,
-        'originator': originator,
-        'recipient': recipient.id,
         'sequential_number': sequential_number,
         'created_on': timezone.now(),
         'received_date': timezone.now(),
     })
 
+    # Some fields are excluded from the form, so we have to
+    # provide a base instance instead
+    base_instance = OutgoingTransmittal(
+        contract_number=contract_nb,
+        originator=originator,
+        recipient=recipient,
+    )
+
     # Let's create the transmittal, then
-    trs_form = OutgoingTransmittalForm(form_data, category=to_category)
-    revision_form = OutgoingTransmittalRevisionForm(form_data, category=to_category)
+    trs_form = OutgoingTransmittalForm(
+        form_data, instance=base_instance, category=to_category)
+    revision_form = OutgoingTransmittalRevisionForm(
+        form_data, category=to_category)
 
     with transaction.atomic():
         doc, trs, revision = save_document_forms(trs_form, revision_form, to_category)


### PR DESCRIPTION
Add a method to easily prepare every document form field.

Makes some outgoing transmittal fields readonly.

Fixes #288