### PR TITLE
notification transmittals

### DIFF
--- a/src/templates/transmittals/pending_ack_email.html
+++ b/src/templates/transmittals/pending_ack_email.html
@@ -1,0 +1,42 @@
+Dear {{ user.username }},
+
+<br />
+<br />
+
+Please note that the following transmittals are pending your acknowledgment of receipt.
+<br />
+<br />
+
+<table style="border:1px solid black; border-collapse: collapse;">
+    <thead>
+    <tr>
+        <th style="border: solid 1px black;">Document number</th>
+        <th style="border: solid 1px black;">Creation date</th>
+    </tr>
+    </thead>
+    <tbody>
+        {% for transmittal in transmittals %}
+<tr>
+    <td style="border: solid 1px black;">
+        <a href="http://{{ site.domain }}{{ transmittal.document.get_absolute_url }}">
+        {{ transmittal.document.document_key }}
+        </a>
+    </td>
+    <td style="border: solid 1px black;">{{ transmittal.document.created_on|date:'SHORT_DATE_FORMAT' }}</td>
+</tr>
+{% endfor %}
+    </tbody>
+</table>
+
+<br />
+<br />
+
+<a href="http://{{ site.domain }}{% url 'category_list' %}">
+    You can download the documents on Phase.
+</a>
+
+<br />
+<br />
+
+The Phase team.
+

--- a/src/templates/transmittals/pending_ack_email.txt
+++ b/src/templates/transmittals/pending_ack_email.txt
@@ -1,0 +1,14 @@
+Dear {{ user.username }},
+
+Please not that the following transmittals are pending your aknowledgement of receipt.
+
+{% for transmittal in transmittals %}
+ - {{ transmittal.document.document_key }}
+{% endfor %}
+
+You can download the documents on Phase:
+
+http://{{ site.domain }}{% url 'category_list' %}
+
+The Phase team.
+

--- a/src/transmittals/management/commands/send_trs_reminders.py
+++ b/src/transmittals/management/commands/send_trs_reminders.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import logging
+from datetime import timedelta
+
+from itertools import groupby
+
+from django.core.management.base import BaseCommand
+from django.core.mail import send_mail
+from django.template.loader import get_template
+from django.contrib.sites.models import Site
+from django.utils import translation, timezone
+from django.conf import settings
+
+from transmittals.models import OutgoingTransmittal
+
+BODY_TEMPLATE = 'transmittals/pending_ack_email.txt'
+HTML_BODY_TEMPLATE = 'transmittals/pending_ack_email.html'
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Send reminders for trs with missing ack of receipt.'
+
+    def handle(self, *args, **options):
+
+        if not settings.SEND_EMAIL_REMINDERS:
+            return
+
+        logger.info('Sending transmittal reminders')
+
+        translation.activate(settings.LANGUAGE_CODE)
+
+        self.body_template = get_template(BODY_TEMPLATE)
+        self.html_body_template = get_template(HTML_BODY_TEMPLATE)
+        self.site = Site.objects.get_current()
+
+        delta = timezone.now().date() - timedelta(days=1)
+        transmittals = OutgoingTransmittal.objects \
+            .filter(ack_of_receipt_date__isnull=True) \
+            .filter(document__created_on__lt=delta) \
+            .select_related() \
+            .prefetch_related('recipient__users')
+
+        recipients = groupby(transmittals, lambda trs: trs.recipient)
+        for recipient, transmittals in recipients:
+            self.send_reminder(recipient, list(transmittals))
+
+    def send_reminder(self, recipient, transmittals):
+        """Send the reminder email."""
+        logger.info('Sending reminders for recipient {}'.format(recipient.name))
+
+        for user in recipient.users.all():
+            send_mail(
+                self.get_subject(user, transmittals),
+                self.get_body(user, transmittals),
+                settings.DEFAULT_FROM_EMAIL,
+                [user.email],
+                html_message=self.get_html_body(user, transmittals),
+                fail_silently=False)
+
+    def get_subject(self, user, transmittals):
+        return 'Phase - Transmittals pending acknowledgment of receipt'
+
+    def get_body(self, user, transmittals):
+        return self.body_template.render({
+            'user': user,
+            'transmittals': transmittals,
+            'site': self.site,
+        })
+
+    def get_html_body(self, user, transmittals):
+        return self.html_body_template.render({
+            'user': user,
+            'transmittals': transmittals,
+            'site': self.site,
+        })

--- a/src/transmittals/tests/test_emails.py
+++ b/src/transmittals/tests/test_emails.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from datetime import timedelta
+
 from django.test import TestCase
 from django.core import mail
+from django.core.management import call_command
+from django.utils import timezone
 
 from accounts.factories import UserFactory
 from transmittals.factories import create_transmittal
@@ -10,9 +14,6 @@ from transmittals.utils import send_transmittal_creation_notifications
 
 
 class TransmittalNotificationTests(TestCase):
-    def setUp(self):
-        pass
-
     def test_empty_notification_list(self):
         trs = create_transmittal()
         rev = trs.latest_revision
@@ -30,3 +31,32 @@ class TransmittalNotificationTests(TestCase):
 
         send_transmittal_creation_notifications(trs, rev)
         self.assertEqual(len(mail.outbox), 3)
+
+
+class TransmittalReminderTests(TestCase):
+    def setUp(self):
+        self.trs = create_transmittal()
+        self.trs.recipient.users.add(UserFactory(email='riri@duck.com'))
+        self.trs.recipient.users.add(UserFactory(email='fifi@duck.com'))
+        self.trs.recipient.users.add(UserFactory(email='loulou@duck.com'))
+
+    def test_send_reminder_before_timer(self):
+        call_command('send_trs_reminders')
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_send_reminders(self):
+        two_days_ago = timezone.now().date() - timedelta(days=2)
+        self.trs.document.created_on = two_days_ago
+        self.trs.document.save()
+
+        call_command('send_trs_reminders')
+        self.assertEqual(len(mail.outbox), 3)
+
+    def test_send_reminders_when_already_acked(self):
+        two_days_ago = timezone.now().date() - timedelta(days=2)
+        self.trs.document.created_on = two_days_ago
+        self.trs.document.save()
+        self.trs.ack_receipt(UserFactory())
+
+        call_command('send_trs_reminders')
+        self.assertEqual(len(mail.outbox), 0)


### PR DESCRIPTION
[https://trello.com/c/aBqqlQxG/222-envoyer-des-emails-de-notifications-lies-aux-transmittals-n-ayant-pas-ete-receptionnes](Envoyer des emails de notifications liés aux transmittals n'ayant pas été réceptionnés)