### PR TITLE
Overdue reviews reminders

### DIFF
--- a/src/documents/tests/test_models.py
+++ b/src/documents/tests/test_models.py
@@ -10,6 +10,7 @@ from documents.factories import DocumentFactory
 from accounts.models import User
 from accounts.factories import UserFactory
 
+
 class DocumentTest(TestCase):
     maxDiff = None
 

--- a/src/reviews/management/commands/send_review_reminders.py
+++ b/src/reviews/management/commands/send_review_reminders.py
@@ -40,7 +40,6 @@ class Command(BaseCommand):
 
     def remind_user_of_pending_reviews(self, user, reviews):
         """Send the reminder email."""
-        import pdb; pdb.set_trace()
         send_mail(
             self.get_subject(user, reviews),
             self.get_body(user, reviews),

--- a/src/reviews/models.py
+++ b/src/reviews/models.py
@@ -144,6 +144,34 @@ class Review(models.Model):
         if save:
             self.save()
 
+    def is_overdue(self):
+        """Tells if the review is overdue.
+
+        A review is overdue only if it's ongoing (ended reviews cannot
+        be overdue) and the due date is past.
+
+        """
+        today = timezone.now().date()
+        return self.due_date < today and self.closed_on is None
+
+    def days_of_delay(self):
+        """Gets the number of days between the due date and the review end.
+
+        If the review has ended, returns delay between the due date and
+        the completion date.
+
+        If the review is ongoing, returns delay between the due date and the
+        present day.
+
+        """
+        if self.closed_on:
+            checked_date = self.closed_on
+        else:
+            checked_date = timezone.now().date()
+
+        delta = checked_date - self.due_date
+        return delta.days
+
     def get_comments_url(self):
         return reverse('download_review_comments', args=[
             self.document.document_key,
@@ -526,27 +554,6 @@ class ReviewMixin(models.Model):
         return self.is_under_review() and self.review_due_date < today
 
     is_overdue.short_description = _('Overdue')
-
-    def days_of_delay(self):
-        """Gets the number of days between the due date and the review end.
-
-        If the review has ended, returns delay between the due date and
-        the completion date.
-
-        If the review is ongoing, returns delay between the due date and the
-        present day.
-
-        """
-        if not self.review_start_date:
-            return None
-
-        if self.review_end_date:
-            checked_date = self.review_end_date
-        else:
-            checked_date = timezone.now().date()
-
-        delta = checked_date - self.review_due_date
-        return delta.days
 
     def current_review_step(self):
         """Return a string representing the current step."""

--- a/src/reviews/models.py
+++ b/src/reviews/models.py
@@ -527,6 +527,27 @@ class ReviewMixin(models.Model):
 
     is_overdue.short_description = _('Overdue')
 
+    def days_of_delay(self):
+        """Gets the number of days between the due date and the review end.
+
+        If the review has ended, returns delay between the due date and
+        the completion date.
+
+        If the review is ongoing, returns delay between the due date and the
+        present day.
+
+        """
+        if not self.review_start_date:
+            return None
+
+        if self.review_end_date:
+            checked_date = self.review_end_date
+        else:
+            checked_date = timezone.now().date()
+
+        delta = checked_date - self.review_due_date
+        return delta.days
+
     def current_review_step(self):
         """Return a string representing the current step."""
         if self.review_start_date is None:

--- a/src/templates/reviews/pending_reviews_reminder_email.html
+++ b/src/templates/reviews/pending_reviews_reminder_email.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 Dear {{ user.username }},
 
 <br />
@@ -36,7 +37,14 @@ Please note that the following documents are pending your review in Phase.
     <td style="border: solid 1px black;">{{ review.get_status_display }}</td>
     <td style="border: solid 1px black;">{{ review.get_role_display }}</td>
     <td style="border: solid 1px black;">{{ review.due_date|date:'SHORT_DATE_FORMAT' }}</td>
-    <td style="border: solid 1px black;">{{ review.is_overdue|yesno:"Yes,No" }}</td>
+    <td style="border: solid 1px black;">
+        {{ review.is_overdue|yesno:"Yes,No" }}
+        {% if review.is_overdue %}
+        {% blocktrans with review.days_of_delay as delay %}
+            ({{ delay}} days)
+        {% endblocktrans %}
+        {% endif %}
+    </td>
 </tr>
 {% endfor %}
     </tbody>

--- a/src/templates/reviews/pending_reviews_reminder_email.html
+++ b/src/templates/reviews/pending_reviews_reminder_email.html
@@ -15,13 +15,17 @@ Please note that the following documents are pending your review in Phase.
         <th style="border: solid 1px black;">Title</th>
         <th style="border: solid 1px black;">Rev.</th>
         <th style="border: solid 1px black;">Status</th>
-        <th style="border: solid 1px black;">Due date</th>
         <th style="border: solid 1px black;">Role</th>
+        <th style="border: solid 1px black;">Due date</th>
+        <th style="border: solid 1px black;">Overdue</th>
     </tr>
     </thead>
     <tbody>
 {% for review in reviews %}
-<tr>
+<tr
+    {% if review.is_overdue %}
+        style="border: solid 2px black"
+    {% endif %}>
     <td style="border: solid 1px black;">
         <a href="http://{{ site.domain }}{% url 'review_document' review.document.document_key %}">
         {{ review.document.document_key }}
@@ -30,8 +34,9 @@ Please note that the following documents are pending your review in Phase.
     <td style="border: solid 1px black;">{{ review.document.title }}</td>
     <td style="border: solid 1px black;">{{ review.revision_name }}</td>
     <td style="border: solid 1px black;">{{ review.get_status_display }}</td>
-    <td style="border: solid 1px black;">{{ review.due_date|date:'SHORT_DATE_FORMAT' }}</td>
     <td style="border: solid 1px black;">{{ review.get_role_display }}</td>
+    <td style="border: solid 1px black;">{{ review.due_date|date:'SHORT_DATE_FORMAT' }}</td>
+    <td style="border: solid 1px black;">{{ review.is_overdue|yesno:"Yes,No" }}</td>
 </tr>
 {% endfor %}
     </tbody>


### PR DESCRIPTION
Premier prototype [pour ce trello](https://trello.com/c/UoBtqNXU/220-envoyer-des-emails-de-notifications-lies-aux-documents-overdues).