### PR TITLE
Add user settings to control which notifications are sent

### DIFF
--- a/src/accounts/admin.py
+++ b/src/accounts/admin.py
@@ -37,6 +37,10 @@ class UserAdmin(django_UserAdmin):
     fieldsets = (
         (None, {'fields': ('email', 'username', 'password')}),
         ('Personal info', {'fields': ('name', 'position',)}),
+        ('Mail settings', {'fields': (
+            'send_closed_reviews_mails',
+            'send_pending_reviews_mails',
+            'send_trs_reminders_mails')}),
         ('Permissions', {'fields': ('is_superuser', 'is_external')}),
         ('Important dates', {'fields': ('date_joined', 'last_login',)}),
         ('Permissions', {'fields': ('groups', 'user_permissions',)}),

--- a/src/accounts/migrations/0008_auto_20160303_1439.py
+++ b/src/accounts/migrations/0008_auto_20160303_1439.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0007_auto_20160225_1510'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='send_closed_reviews_mails',
+            field=models.BooleanField(default=True, verbose_name='Send mails when reviews are closed'),
+        ),
+        migrations.AddField(
+            model_name='user',
+            name='send_pending_reviews_mails',
+            field=models.BooleanField(default=True, verbose_name='Send pending reviews reminders'),
+        ),
+        migrations.AddField(
+            model_name='user',
+            name='send_trs_reminders_mails',
+            field=models.BooleanField(default=True, verbose_name='Send reminders for trs with missing ack of receipt'),
+        ),
+    ]

--- a/src/accounts/models.py
+++ b/src/accounts/models.py
@@ -90,6 +90,16 @@ class User(AbstractBaseUser, PermissionsMixin):
         _('date joined'),
         default=timezone.now)
 
+    send_closed_reviews_mails = models.BooleanField(
+        _('Send mails when reviews are closed'),
+        default=True)
+    send_pending_reviews_mails = models.BooleanField(
+        _('Send pending reviews reminders'),
+        default=True)
+    send_trs_reminders_mails = models.BooleanField(
+        _('Send reminders for trs with missing ack of receipt'),
+        default=True)
+
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = ['name', 'username']
 

--- a/src/reviews/management/commands/send_closed_reviews_notifications.py
+++ b/src/reviews/management/commands/send_closed_reviews_notifications.py
@@ -35,4 +35,4 @@ class Command(EmailCommand):
 
     def get_recipient_list(self, **kwargs):
         originator = kwargs['originator']
-        return [u.email for u in originator.users.all()]
+        return [u.email for u in originator.users.all() if u.send_closed_reviews_mails]

--- a/src/reviews/management/commands/send_review_reminders.py
+++ b/src/reviews/management/commands/send_review_reminders.py
@@ -19,6 +19,8 @@ class Command(EmailCommand):
             .order_by('reviewer', 'role')
         users = groupby(pending_reviews, lambda rev: rev.reviewer)
         for user, reviews in users:
+            if not user.send_pending_reviews_mails:
+                continue
             self.send_notification(user=user, reviews=list(reviews))
 
     def get_subject(self, **kwargs):

--- a/src/reviews/tests/test_emails.py
+++ b/src/reviews/tests/test_emails.py
@@ -73,6 +73,7 @@ class ClosedReviewsEmailTests(ContractorDeliverableTestCase):
                 UserFactory(),
                 UserFactory(),
                 UserFactory(),
+                UserFactory(send_closed_reviews_mails=False),
             ]
         )
 
@@ -123,3 +124,6 @@ class ClosedReviewsEmailTests(ContractorDeliverableTestCase):
         self.assertEqual(len(mail.outbox), 0)
         call_command('send_closed_reviews_notifications')
         self.assertEqual(len(mail.outbox), 1)
+        # We have 4 potential recipients but one has `
+        # `send_closed_reviews_mails set to False
+        self.assertEqual(len(mail.outbox[0].to), 3)

--- a/src/reviews/tests/test_emails.py
+++ b/src/reviews/tests/test_emails.py
@@ -61,6 +61,17 @@ class PendingReviewsReminderTests(TestCase):
         call_command('send_review_reminders')
         self.assertEqual(len(mail.outbox), 0)
 
+    def test_do_not_send_reminder(self):
+        """Reminders are not send to users if their mail config says so."""
+        self.doc1.get_latest_revision().start_review()
+        self.assertEqual(Review.objects.all().count(), 1)
+
+        self.user.send_pending_reviews_mails = False
+        self.user.save()
+
+        call_command('send_review_reminders')
+        self.assertEqual(len(mail.outbox), 0)
+
 
 class ClosedReviewsEmailTests(ContractorDeliverableTestCase):
     def setUp(self):

--- a/src/transmittals/management/commands/send_trs_reminders.py
+++ b/src/transmittals/management/commands/send_trs_reminders.py
@@ -35,6 +35,8 @@ class Command(EmailCommand):
         for recipient, transmittals in recipients:
             logger.info('Sending reminders for recipient {}'.format(recipient.name))
             for user in recipient.users.all():
+                if not user.send_trs_reminders_mails:
+                    continue
                 self.send_notification(
                     user=user, transmittals=list(transmittals))
 

--- a/src/transmittals/migrations/0055_auto_20160303_1439.py
+++ b/src/transmittals/migrations/0055_auto_20160303_1439.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import transmittals.fields
+import privatemedia.storage
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transmittals', '0054_outgoingtransmittal_archived_pdf'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='outgoingtransmittal',
+            name='archived_pdf',
+            field=transmittals.fields.OgtFileField(storage=privatemedia.storage.ProtectedStorage(), upload_to=transmittals.fields.ogt_file_path, null=True, verbose_name='Archived PDF', blank=True),
+        ),
+    ]

--- a/src/transmittals/tests/test_emails.py
+++ b/src/transmittals/tests/test_emails.py
@@ -39,6 +39,9 @@ class TransmittalReminderTests(TestCase):
         self.trs.recipient.users.add(UserFactory(email='riri@duck.com'))
         self.trs.recipient.users.add(UserFactory(email='fifi@duck.com'))
         self.trs.recipient.users.add(UserFactory(email='loulou@duck.com'))
+        self.trs.recipient.users.add(UserFactory(
+            email='scrooge@duck.com',
+            send_trs_reminders_mails=False))
 
     def test_send_reminder_before_timer(self):
         call_command('send_trs_reminders')


### PR DESCRIPTION
Mail settings can be found in User model admin interface:
* Send mails when reviews are closed
* Send pending reviews reminders
* Send reminders for trs with missing ack of receipt'