### PR TITLE
Gestion des permissions plus fines pour un nouveau type d'utilisateurs 

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,3 +5,12 @@ TODO : Define phase usage
 
 - Category creation
 - Category templates
+
+Users Group
+-----------
+
+Users groups can be defined in django admin interface.
+Permissions must be assigned to control available actions.
+The permissions used in Phase are: documents.add_document,
+documents.can_control_document, documents.can_start_stop_review, and
+transmittals.add_outgoing_transmittal for transmittal generation.

--- a/src/default_documents/models.py
+++ b/src/default_documents/models.py
@@ -357,7 +357,7 @@ class ContractorDeliverable(ScheduleMixin, Metadata):
         actions = super(ContractorDeliverable, cls).get_batch_actions(
             category, user)
 
-        if user.has_perm('documents.can_control_document'):
+        if user.has_perm('documents.can_control_document') and user.has_perm('reviews.can_add_review'):
             actions['start_review'] = MenuItem(
                 'start-review',
                 _('Start review'),
@@ -380,6 +380,8 @@ class ContractorDeliverable(ScheduleMixin, Metadata):
                 progression_modal=True,
                 icon='eye-close',
             )
+
+        if user.has_perm('transmittals.add_outgoingtransmittal'):
             actions['prepare_transmittal'] = MenuItem(
                 'prepare-transmittal',
                 _('Prepare outgoing transmittal'),

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -68,7 +68,8 @@ class Document(models.Model):
         # Custom permission for document controllers
         # Permission used in sidebar template to check if user belongs to
         # doc controller group
-        permissions = (('can_control_document', 'Can control document'),)
+        permissions = (('can_control_document', 'Can control document'),
+                       ('can_start_stop_review', 'Can start stop review'),)
 
     def __unicode__(self):
         return self.document_number

--- a/src/reviews/models.py
+++ b/src/reviews/models.py
@@ -734,9 +734,11 @@ class ReviewMixin(models.Model):
         actions = super(ReviewMixin, self).get_actions(metadata, user)
         category = self.document.category
 
+        can_start_stop_review = user.has_perm('documents.can_start_stop_review')
+
         if self.is_under_review():
 
-            if user.has_perm('documents.can_control_document'):
+            if can_start_stop_review:
                 actions.insert(-3, MenuItem(
                     'cancel-review',
                     _('Cancel review'),
@@ -757,9 +759,8 @@ class ReviewMixin(models.Model):
                 ))
 
         else:  # revision is not under review
-            if self.can_be_reviewed and \
-                    user.has_perm('documents.can_control_document'):
 
+            if self.can_be_reviewed and can_start_stop_review:
                 actions.insert(-3, MenuItem(
                     'start-review',
                     _('Start review'),

--- a/src/reviews/views.py
+++ b/src/reviews/views.py
@@ -44,7 +44,7 @@ class StartReview(PermissionRequiredMixin,
                   SingleObjectMixin,
                   View):
     """Start the review process."""
-    permission_required = 'documents.can_control_document'
+    permission_required = 'documents.can_start_stop_review'
     context_object_name = 'metadata'
 
     def get_redirect_url(self, *args, **kwargs):
@@ -161,7 +161,7 @@ class CancelReview(PermissionRequiredMixin,
 
 class BatchStartReviews(PermissionRequiredMixin, BaseDocumentBatchActionView):
     """Starts the review process for multiple documents at once."""
-    permission_required = 'documents.can_control_document'
+    permission_required = 'documents.can_start_stop_review'
 
     def start_job(self, contenttype, document_ids):
         remark = self.request.POST.get('remark', None)
@@ -176,7 +176,7 @@ class BatchStartReviews(PermissionRequiredMixin, BaseDocumentBatchActionView):
 
 class BatchCancelReviews(PermissionRequiredMixin, BaseDocumentBatchActionView):
     """Cancel several reviews at once."""
-    permission_required = 'documents.can_control_document'
+    permission_required = 'documents.can_start_stop_review'
 
     def start_job(self, contenttype, document_ids):
         job = batch_cancel_reviews.delay(

--- a/src/transmittals/views.py
+++ b/src/transmittals/views.py
@@ -319,7 +319,7 @@ class BatchAckOfTransmittalReceipt(BaseDocumentBatchActionView):
 
 class CreateTransmittal(PermissionRequiredMixin, BaseDocumentBatchActionView):
     """Create a transmittal embedding the given documents"""
-    permission_required = 'documents.can_control_document'
+    permission_required = 'transmittals.add_outgoingtransmittal'
     http_method_names = ['post']
 
     def start_job(self, contenttype, document_ids):


### PR DESCRIPTION
Référence  #395

Cette PR permet:
* de n'afficher les menu de création d'outgoing transmittals qu'aux utilisateurs disposant de la permission create_transmittals
* afficher les menu de start/stop review qu'aux utilisateurs disposant de la permission documents.can_start_stop_review